### PR TITLE
Update the web client ID to reference the new Firestore Database

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">My Application</string>
-    <string name="web_client_id">957415054330-j5fa1cl19qlthoshv7l2cccqv5v4icj4.apps.googleusercontent.com</string>
+    <string name="web_client_id">1043895872028–8m8f4kpcmqe60ofkef734vbgqph8g5ut.apps.googleusercontent.com</string>
+    <string name="default_web_client_id" translatable="false">webClientId.apps.googleusercontent.com</string>
     <string name="test1">test1</string>
     <string name="test2">test2</string>
     <string name="overview">Overview</string>


### PR DESCRIPTION
## Objective
Fix bug caused by using old web-client-id from the bootcamp to link to Firebase. Also add a default web client id.

## Key Changes
- [ ] replace the old web-client-id with the new database ID
- [ ] add a default web-client-id