### PR TITLE
Update Config File and Web Client ID for Google Authentication to Current Project Firebase

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -12,7 +12,20 @@
           "package_name": "com.github.se.eventradar"
         }
       },
-      "oauth_client": [],
+      "oauth_client": [
+        {
+          "client_id": "1043895872028-9ioo4qv653erkc4mjk2iamgnb05aoccm.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.github.se.eventradar",
+            "certificate_hash": "2c45b8ed3561a0f5fc5965ca4ec994f84eb1fff2"
+          }
+        },
+        {
+          "client_id": "1043895872028-8m8f4kpcmqe60ofkef734vbgqph8g5ut.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
           "current_key": "AIzaSyCSsyVzBHrtEzBMeGjCATj-Y8IIhbcnnoA"
@@ -20,7 +33,12 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "1043895872028-8m8f4kpcmqe60ofkef734vbgqph8g5ut.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         }
       }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">My Application</string>
-    <string name="web_client_id">957415054330-j5fa1cl19qlthoshv7l2cccqv5v4icj4.apps.googleusercontent.com</string>
+    <string name="web_client_id">1043895872028–8m8f4kpcmqe60ofkef734vbgqph8g5ut.apps.googleusercontent.com</string>
+    <string name="default_web_client_id" translatable="false">webClientId.apps.googleusercontent.com</string>
     <string name="test1">test1</string>
     <string name="test2">test2</string>
     <string name="overview">Overview</string>


### PR DESCRIPTION
## Objective
Fix bug caused by using old web-client-id and `google-services.json` config file from the bootcamp, by linking it to current project Firebase. Also add a default web client id.

## Key Changes
- [x] Replace the old web-client-id with the new database ID
- [x] Replace old `google-services.json` config file with new config file from project firebase
- [x] Add a default web-client-id