### PR TITLE
Replace mock events with events from Firebase

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -1,8 +1,14 @@
 package com.github.se.eventradar.home
 
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eventradar.model.EventsOverviewUiState
+import com.github.se.eventradar.model.EventsOverviewViewModel
+import com.github.se.eventradar.model.Location
+import com.github.se.eventradar.model.event.Event
+import com.github.se.eventradar.model.event.EventCategory
+import com.github.se.eventradar.model.event.EventList
+import com.github.se.eventradar.model.event.EventTicket
 import com.github.se.eventradar.screens.HomeScreen
 import com.github.se.eventradar.ui.home.HomeScreen
 import com.github.se.eventradar.ui.navigation.NavigationActions
@@ -10,6 +16,13 @@ import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.verify
+import java.time.LocalDateTime
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,9 +33,42 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  // This rule automatic initializes lateinit properties with @MockK, @RelaxedMockK, etc.
+  @get:Rule val mockkRule = MockKRule(this)
+
+  // Relaxed mocks methods have a default implementation returning values
+  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+
+  @RelaxedMockK lateinit var mockEventsOverviewViewModel: EventsOverviewViewModel
+
+  private val sampleEventList =
+      MutableStateFlow(
+          EventsOverviewUiState(
+              eventList =
+                  EventList(
+                      List(20) {
+                        Event(
+                            eventName = "Event $it",
+                            eventPhoto = "",
+                            start = LocalDateTime.now(),
+                            end = LocalDateTime.now(),
+                            location = Location(0.0, 0.0, "Test Location"),
+                            description = "Test Description",
+                            ticket = EventTicket("Test Ticket", 0.0, 1),
+                            contact = "Test Contact Email",
+                            organiserList = setOf("Test Organiser"),
+                            attendeeList = setOf("Test Attendee"),
+                            category = EventCategory.COMMUNITY,
+                            fireBaseID = "$it")
+                      })))
+
   @Before
   fun testSetup() {
-    composeTestRule.setContent { HomeScreen(NavigationActions(rememberNavController())) }
+    every { mockEventsOverviewViewModel.getEvents() } returns Unit
+
+    every { mockEventsOverviewViewModel.uiState } returns sampleEventList
+
+    composeTestRule.setContent { HomeScreen(mockEventsOverviewViewModel, mockNavActions) }
   }
 
   @Test
@@ -34,6 +80,15 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       browseTab { assertIsDisplayed() }
       eventCard { assertIsDisplayed() }
       bottomNav { assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun getEventsIsCalledOnLaunch() = run {
+    onComposeScreen<HomeScreen>(composeTestRule) {
+      verify(exactly = 1) { mockEventsOverviewViewModel.getEvents() }
+      verify(exactly = 1) { mockEventsOverviewViewModel.uiState }
+      confirmVerified(mockEventsOverviewViewModel)
     }
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -43,61 +45,23 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import com.github.se.eventradar.R
-import com.github.se.eventradar.model.Location
+import com.github.se.eventradar.model.EventsOverviewViewModel
 import com.github.se.eventradar.model.event.Event
-import com.github.se.eventradar.model.event.EventCategory
-import com.github.se.eventradar.model.event.EventTicket
 import com.github.se.eventradar.ui.BottomNavigationMenu
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
-import java.time.LocalDateTime
 
 @Composable
-fun HomeScreen(navigationActions: NavigationActions) {
+fun HomeScreen(
+    viewModel: EventsOverviewViewModel = viewModel(),
+    navigationActions: NavigationActions
+) {
+  val uiState by viewModel.uiState.collectAsState()
 
-  val mockEvents =
-      listOf(
-          Event(
-              "NYE2025",
-              "User1", // todo
-              LocalDateTime.MIN,
-              LocalDateTime.MAX,
-              Location(83.39, 2.992, "EPFL"),
-              "enjoy your time on the dacefloor",
-              EventTicket("Standard", 0.0, 500),
-              "jg@joytigoel.com",
-              mutableSetOf("2989jdgj23", "32923jkbd23"),
-              mutableSetOf("20982jwdwk", "j1ou1e]d8223"),
-              EventCategory.MUSIC,
-              "89379"),
-          Event(
-              "NYE2026",
-              "User2", // todo
-              LocalDateTime.now(),
-              LocalDateTime.MAX,
-              Location(83.49, 56.992, "161 makepeace avenue, n666es"),
-              "Forget and Enjoy",
-              EventTicket("regular", 0.0, 10000),
-              "valerian@joytigoel.com",
-              mutableSetOf("298jhk", "jwj8223"),
-              mutableSetOf("20982jhk", "j1ou1e8223"),
-              EventCategory.SPORTS,
-              "89298"),
-          Event(
-              "NYE2027",
-              "User3", // todo
-              LocalDateTime.now(),
-              LocalDateTime.MIN,
-              Location(83.39, 66.992, "161 makepeace avenue, n666es"),
-              "Join the Community",
-              EventTicket("regular", 0.0, 10000),
-              "valerian@joytigoel.com",
-              mutableSetOf("298jhk", "jwj8223"),
-              mutableSetOf("20982e2hk", "j1ou223e8223"),
-              EventCategory.COMMUNITY,
-              "89298"))
+  LaunchedEffect(key1 = uiState.eventList) { viewModel.getEvents() }
 
   var selectedTabIndex by remember { mutableIntStateOf(0) }
   val context = LocalContext.current
@@ -172,7 +136,7 @@ fun HomeScreen(navigationActions: NavigationActions) {
 
     if (selectedTabIndex == 0) {
       EventList(
-          mockEvents,
+          uiState.eventList.allEvents,
           Modifier.fillMaxWidth().constrainAs(eventList) {
             top.linkTo(tabs.bottom, margin = 8.dp)
             start.linkTo(parent.start)
@@ -256,5 +220,5 @@ fun EventCard(event: Event) {
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun HomeScreenPreview() {
-  HomeScreen(NavigationActions(rememberNavController()))
+  HomeScreen(EventsOverviewViewModel(), NavigationActions(rememberNavController()))
 }


### PR DESCRIPTION
## Objective
- Link the `EventsOverviewViewModel` to the Home screen
- query events from the database into browse events

## Key Changes
- [ ] remove `mockEvents`
- [ ] use the view model `getEvents()` function to get events from Firebase
- [ ] add a test