### PR TITLE
Move mock database modules to `androidTest` folder

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/MockDatabaseModules.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/MockDatabaseModules.kt
@@ -1,0 +1,35 @@
+package com.github.se.eventradar
+
+import com.github.se.eventradar.model.di.FirebaseEventDatabaseModule
+import com.github.se.eventradar.model.di.FirebaseUserDatabaseModule
+import com.github.se.eventradar.model.repository.event.IEventRepository
+import com.github.se.eventradar.model.repository.event.MockEventRepository
+import com.github.se.eventradar.model.repository.user.IUserRepository
+import com.github.se.eventradar.model.repository.user.MockUserRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class], replaces = [FirebaseEventDatabaseModule::class])
+class MockEventDatabaseModule {
+  @Provides
+  @Singleton
+  fun provideMockEventRepository(): IEventRepository {
+    return MockEventRepository()
+  }
+}
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class], replaces = [FirebaseUserDatabaseModule::class])
+class MockUserDatabaseModule {
+  @Provides
+  @Singleton
+  fun provideMockUserRepository(): IUserRepository {
+    return MockUserRepository()
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/di/EventDatabaseModule.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/di/EventDatabaseModule.kt
@@ -2,36 +2,18 @@ package com.github.se.eventradar.model.di
 
 import com.github.se.eventradar.model.repository.event.FirebaseEventRepository
 import com.github.se.eventradar.model.repository.event.IEventRepository
-import com.github.se.eventradar.model.repository.event.MockEventRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Qualifier
 import javax.inject.Singleton
-
-@Qualifier annotation class FirebaseEventModule
-
-@Qualifier annotation class MockEventModule
 
 @Module
 @InstallIn(SingletonComponent::class)
 class FirebaseEventDatabaseModule {
   @Provides
-  @FirebaseEventModule
   @Singleton
   fun provideFirebaseEventRepository(): IEventRepository {
     return FirebaseEventRepository()
-  }
-}
-
-@Module
-@InstallIn(SingletonComponent::class)
-class MockEventDatabaseModule {
-  @Provides
-  @MockEventModule
-  @Singleton
-  fun provideMockEventRepository(): IEventRepository {
-    return MockEventRepository()
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/di/UserDatabaseModule.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/di/UserDatabaseModule.kt
@@ -2,36 +2,18 @@ package com.github.se.eventradar.model.di
 
 import com.github.se.eventradar.model.repository.user.FirebaseUserRepository
 import com.github.se.eventradar.model.repository.user.IUserRepository
-import com.github.se.eventradar.model.repository.user.MockUserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Qualifier
 import javax.inject.Singleton
-
-@Qualifier annotation class FirebaseUserModule
-
-@Qualifier annotation class MockUserModule
 
 @Module
 @InstallIn(SingletonComponent::class)
 class FirebaseUserDatabaseModule {
   @Provides
-  @FirebaseUserModule
   @Singleton
   fun provideFirebaseUserRepository(): IUserRepository {
     return FirebaseUserRepository()
-  }
-}
-
-@Module
-@InstallIn(SingletonComponent::class)
-class MockUserDatabaseModule {
-  @Provides
-  @MockUserModule
-  @Singleton
-  fun provideMockUserRepository(): IUserRepository {
-    return MockUserRepository()
   }
 }


### PR DESCRIPTION
## Objective
- fix error with Hilt when providing two modules in production code for the same repository

## Key Changes
- [ ] add a mock database modules file that holds the mock user and event databases
- [ ] add a `@TestInstallsIn` annotation to instruct Hilt to provide those modules in place of the Firebase modules
- [ ] delete the old modules in production code
- [ ] remove all qualifiers