### PR TITLE
Create a Messages Repository Implementation

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/MockDatabaseModules.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/MockDatabaseModules.kt
@@ -1,9 +1,12 @@
 package com.github.se.eventradar
 
 import com.github.se.eventradar.model.di.FirebaseEventDatabaseModule
+import com.github.se.eventradar.model.di.FirebaseMessageDatabaseModule
 import com.github.se.eventradar.model.di.FirebaseUserDatabaseModule
 import com.github.se.eventradar.model.repository.event.IEventRepository
 import com.github.se.eventradar.model.repository.event.MockEventRepository
+import com.github.se.eventradar.model.repository.message.IMessageRepository
+import com.github.se.eventradar.model.repository.message.MockMessageRepository
 import com.github.se.eventradar.model.repository.user.IUserRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository
 import dagger.Module
@@ -31,5 +34,16 @@ class MockUserDatabaseModule {
   @Singleton
   fun provideMockUserRepository(): IUserRepository {
     return MockUserRepository()
+  }
+}
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class], replaces = [FirebaseMessageDatabaseModule::class])
+class MockMessageDatabaseModule {
+  @Provides
+  @Singleton
+  fun provideMockMessageRepository(): IMessageRepository {
+    return MockMessageRepository()
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/di/MessageDatabaseModule.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/di/MessageDatabaseModule.kt
@@ -1,0 +1,19 @@
+package com.github.se.eventradar.model.di
+
+import com.github.se.eventradar.model.repository.message.FirebaseMessageRepository
+import com.github.se.eventradar.model.repository.message.IMessageRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class FirebaseMessageDatabaseModule {
+  @Provides
+  @Singleton
+  fun provideFirebaseMessageRepository(): IMessageRepository {
+    return FirebaseMessageRepository()
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/message/Message.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/message/Message.kt
@@ -3,21 +3,21 @@ package com.github.se.eventradar.model.message
 import java.time.LocalDateTime
 
 data class Message(
-  val sender: String,
-  val content: String,
-  val dateTimeSent: LocalDateTime,
-  val isRead: Boolean,
-  val id: String,
+    val sender: String,
+    val content: String,
+    var dateTimeSent: LocalDateTime,
+    var isRead: Boolean,
+    val id: String,
 ) {
   constructor(
-    map: Map<String, Any>,
-    id: String = "",
+      map: Map<String, Any>,
+      id: String = "",
   ) : this(
-    sender = map["sender"] as String,
-    content = map["content"] as String,
-    dateTimeSent = map["date_time_sent"] as LocalDateTime,
-    isRead = map["message_read"] as Boolean,
-    id = id,
+      sender = map["sender"] as String,
+      content = map["content"] as String,
+      dateTimeSent = map["date_time_sent"] as LocalDateTime,
+      isRead = map["message_read"] as Boolean,
+      id = id,
   )
 
   fun toMap(): HashMap<String, Any> {

--- a/app/src/main/java/com/github/se/eventradar/model/message/Message.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/message/Message.kt
@@ -1,0 +1,31 @@
+package com.github.se.eventradar.model.message
+
+import java.time.LocalDateTime
+
+data class Message(
+  val sender: String,
+  val content: String,
+  val dateTimeSent: LocalDateTime,
+  val isRead: Boolean,
+  val id: String,
+) {
+  constructor(
+    map: Map<String, Any>,
+    id: String = "",
+  ) : this(
+    sender = map["sender"] as String,
+    content = map["content"] as String,
+    dateTimeSent = map["date_time_sent"] as LocalDateTime,
+    isRead = map["message_read"] as Boolean,
+    id = id,
+  )
+
+  fun toMap(): HashMap<String, Any> {
+    val map = HashMap<String, Any>()
+    map["sender"] = sender
+    map["content"] = content
+    map["date_time_sent"] = dateTimeSent
+    map["message_read"] = isRead
+    return map
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
@@ -1,8 +1,8 @@
 package com.github.se.eventradar.model.message
 
 data class MessageHistory(
-    val fromUser: String,
-    val toUser: String,
+    val user1: String,
+    val user2: String,
     var latestMessageId: String,
     val messages: MutableList<Message>,
     val id: String = "",
@@ -11,8 +11,8 @@ data class MessageHistory(
       map: Map<String, Any>,
       id: String,
   ) : this(
-      fromUser = map["from_user"] as String,
-      toUser = map["to_user"] as String,
+      user1 = map["from_user"] as String,
+      user2 = map["to_user"] as String,
       latestMessageId = map["latest_message_id"] as String,
       messages = getMapOfMessages(map["messages"]).map { Message(it) }.toMutableList(),
       id = id,
@@ -20,8 +20,8 @@ data class MessageHistory(
 
   fun toMap(): HashMap<String, Any> {
     val map = HashMap<String, Any>()
-    map["from_user"] = fromUser
-    map["to_user"] = toUser
+    map["from_user"] = user1
+    map["to_user"] = user2
     map["latest_message_id"] = latestMessageId
     map["messages"] = messages.map { it.toMap() }
     return map

--- a/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
@@ -1,21 +1,21 @@
 package com.github.se.eventradar.model.message
 
 data class MessageHistory(
-  val fromUser: String,
-  val toUser: String,
-  val latestMessageId: String,
-  val messages: List<Message>,
-  val id: String = "",
+    val fromUser: String,
+    val toUser: String,
+    var latestMessageId: String,
+    val messages: MutableList<Message>,
+    val id: String = "",
 ) {
   constructor(
-    map: Map<String, Any>,
-    id: String,
+      map: Map<String, Any>,
+      id: String,
   ) : this(
-    fromUser = map["from_user"] as String,
-    toUser = map["to_user"] as String,
-    latestMessageId = map["latest_message_id"] as String,
-    messages = getMapOfMessages(map["messages"]).map { Message(it) },
-    id = id,
+      fromUser = map["from_user"] as String,
+      toUser = map["to_user"] as String,
+      latestMessageId = map["latest_message_id"] as String,
+      messages = getMapOfMessages(map["messages"]).map { Message(it) }.toMutableList(),
+      id = id,
   )
 
   fun toMap(): HashMap<String, Any> {
@@ -30,7 +30,7 @@ data class MessageHistory(
 
 private fun getMapOfMessages(map: Any?): List<Map<String, Any>> {
   return when (map) {
-    is List<*> -> map.filterIsInstance<Map<String, Any>>().toList()
+    is List<*> -> map.filterIsInstance<Map<String, Any>>().toMutableList()
     else -> emptyList()
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/message/MessageHistory.kt
@@ -1,0 +1,36 @@
+package com.github.se.eventradar.model.message
+
+data class MessageHistory(
+  val fromUser: String,
+  val toUser: String,
+  val latestMessageId: String,
+  val messages: List<Message>,
+  val id: String = "",
+) {
+  constructor(
+    map: Map<String, Any>,
+    id: String,
+  ) : this(
+    fromUser = map["from_user"] as String,
+    toUser = map["to_user"] as String,
+    latestMessageId = map["latest_message_id"] as String,
+    messages = getMapOfMessages(map["messages"]).map { Message(it) },
+    id = id,
+  )
+
+  fun toMap(): HashMap<String, Any> {
+    val map = HashMap<String, Any>()
+    map["from_user"] = fromUser
+    map["to_user"] = toUser
+    map["latest_message_id"] = latestMessageId
+    map["messages"] = messages.map { it.toMap() }
+    return map
+  }
+}
+
+private fun getMapOfMessages(map: Any?): List<Map<String, Any>> {
+  return when (map) {
+    is List<*> -> map.filterIsInstance<Map<String, Any>>().toList()
+    else -> emptyList()
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/FirebaseMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/FirebaseMessageRepository.kt
@@ -1,0 +1,84 @@
+package com.github.se.eventradar.model.repository.message
+
+import com.github.se.eventradar.model.Resource
+import com.github.se.eventradar.model.message.Message
+import com.github.se.eventradar.model.message.MessageHistory
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.Filter
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+import java.time.LocalDateTime
+
+class FirebaseMessageRepository : IMessageRepository {
+  private val db: FirebaseFirestore = Firebase.firestore
+  private val messageRef: CollectionReference = db.collection("messages")
+
+  override suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory> {
+    val resultDocument =
+        messageRef
+            .where(
+                Filter.or(
+                    Filter.and(
+                        Filter.arrayContains("from_user", user1),
+                        Filter.arrayContains("to_user", user2)),
+                    Filter.and(
+                        Filter.arrayContains("from_user", user2),
+                        Filter.arrayContains("to_user", user1)),
+                ))
+            .limit(1)
+            .get()
+            .await()
+    
+    return try {
+      val result = resultDocument.documents[0]
+      val messageHistory = MessageHistory(result.data!!, result.id)
+      Resource.Success(messageHistory)
+    } catch (e: Exception) {
+      Resource.Failure(e)
+    }
+  }
+
+  override suspend fun addMessage(
+      message: Message,
+      messageHistory: MessageHistory
+  ): Resource<Unit> {
+    return try {
+      val newMessage = messageRef.document(messageHistory.id).collection("messages").add(message.toMap()).await()
+      messageRef.document(messageHistory.id).update("latest_message_id", newMessage.id).await()
+      Resource.Success(Unit)
+    } catch (e: Exception) {
+      Resource.Failure(e)
+    }
+  }
+  
+  override suspend fun updateMessageToReadState(
+    message: Message,
+    messageHistory: MessageHistory
+  ): Resource<Unit> {
+    return try {
+      messageRef.document(messageHistory.id).collection("messages").document(message.id).update(
+        mapOf("message_read" to message.isRead, "date_time_read" to LocalDateTime.now()) // TODO: parse as String
+      ).await()
+      Resource.Success(Unit)
+    } catch (e: Exception) {
+      Resource.Failure(e)
+    }
+  }
+  
+  override suspend fun createNewMessageHistory(user1: String, user2: String): Resource<MessageHistory> {
+    val messageHistory = MessageHistory(
+        fromUser = user1,
+        toUser = user2,
+        latestMessageId = "",
+        messages = emptyList()
+    )
+    return try {
+      messageRef.add(messageHistory.toMap()).await()
+      Resource.Success(messageHistory)
+    } catch (e: Exception) {
+      Resource.Failure(e)
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/FirebaseMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/FirebaseMessageRepository.kt
@@ -8,7 +8,6 @@ import com.google.firebase.firestore.Filter
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
-import java.time.LocalDateTime
 import kotlinx.coroutines.tasks.await
 
 class FirebaseMessageRepository : IMessageRepository {
@@ -16,6 +15,7 @@ class FirebaseMessageRepository : IMessageRepository {
   private val messageRef: CollectionReference = db.collection("messages")
 
   override suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory> {
+    // From and to user are interchangeable
     val resultDocument =
         messageRef
             .where(
@@ -63,7 +63,7 @@ class FirebaseMessageRepository : IMessageRepository {
           .document(messageHistory.id)
           .collection("messages")
           .document(message.id)
-          .update(mapOf("message_read" to message.isRead, "date_time_read" to LocalDateTime.now()))
+          .update(mapOf("message_read" to message.isRead))
           .await()
       Resource.Success(Unit)
     } catch (e: Exception) {
@@ -77,8 +77,8 @@ class FirebaseMessageRepository : IMessageRepository {
   ): Resource<MessageHistory> {
     val messageHistory =
         MessageHistory(
-            fromUser = user1,
-            toUser = user2,
+            user1 = user1,
+            user2 = user2,
             latestMessageId = "",
             messages = mutableListOf(),
         )

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/IMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/IMessageRepository.kt
@@ -1,0 +1,15 @@
+package com.github.se.eventradar.model.repository.message
+
+import com.github.se.eventradar.model.Resource
+import com.github.se.eventradar.model.message.Message
+import com.github.se.eventradar.model.message.MessageHistory
+
+interface IMessageRepository {
+  suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory>
+  
+  suspend fun addMessage(message: Message, messageHistory: MessageHistory): Resource<Unit>
+  
+  suspend fun updateMessageToReadState(message: Message, messageHistory: MessageHistory): Resource<Unit>
+  
+  suspend fun createNewMessageHistory(user1: String, user2: String): Resource<MessageHistory>
+}

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/IMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/IMessageRepository.kt
@@ -6,10 +6,13 @@ import com.github.se.eventradar.model.message.MessageHistory
 
 interface IMessageRepository {
   suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory>
-  
+
   suspend fun addMessage(message: Message, messageHistory: MessageHistory): Resource<Unit>
-  
-  suspend fun updateMessageToReadState(message: Message, messageHistory: MessageHistory): Resource<Unit>
-  
+
+  suspend fun updateMessageToReadState(
+      message: Message,
+      messageHistory: MessageHistory
+  ): Resource<Unit>
+
   suspend fun createNewMessageHistory(user1: String, user2: String): Resource<MessageHistory>
 }

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/MockMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/MockMessageRepository.kt
@@ -1,0 +1,78 @@
+package com.github.se.eventradar.model.repository.message
+
+import com.github.se.eventradar.model.Resource
+import com.github.se.eventradar.model.message.Message
+import com.github.se.eventradar.model.message.MessageHistory
+import java.time.LocalDateTime
+
+class MockMessageRepository : IMessageRepository {
+  private val mockMessageHistory = mutableListOf<MessageHistory>()
+  private var ticker = 0
+
+  override suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory> {
+    val messageHistory =
+        mockMessageHistory.find {
+          (it.fromUser == user1 && it.toUser == user2) ||
+              (it.fromUser == user2 && it.toUser == user1)
+        }
+
+    return if (messageHistory != null) {
+      Resource.Success(messageHistory)
+    } else {
+      createNewMessageHistory(user1, user2)
+    }
+  }
+
+  override suspend fun addMessage(
+      message: Message,
+      messageHistory: MessageHistory
+  ): Resource<Unit> {
+    val addMessage = mockMessageHistory.find { it.id == messageHistory.id }?.messages?.add(message)
+
+    return if (addMessage != null && addMessage) {
+      mockMessageHistory.find { it.id == messageHistory.id }?.latestMessageId = message.id
+      Resource.Success(Unit)
+    } else {
+      Resource.Failure(Exception("MessageHistory with id ${messageHistory.id} not found"))
+    }
+  }
+
+  override suspend fun updateMessageToReadState(
+      message: Message,
+      messageHistory: MessageHistory
+  ): Resource<Unit> {
+    val updateMessage =
+        mockMessageHistory
+            .find { it.id == messageHistory.id }
+            ?.messages
+            ?.find { it.id == message.id }
+            ?.let {
+              it.isRead = true
+              it.dateTimeSent = LocalDateTime.parse("2021-01-01T00:00:00")
+            }
+
+    return if (updateMessage != null) {
+      Resource.Success(Unit)
+    } else {
+      Resource.Failure(
+          Exception(
+              "Message with id ${message.id} not found in MessageHistory with id ${messageHistory.id}"))
+    }
+  }
+
+  override suspend fun createNewMessageHistory(
+      user1: String,
+      user2: String
+  ): Resource<MessageHistory> {
+    val messageHistory =
+        MessageHistory(
+            fromUser = user1,
+            toUser = user2,
+            latestMessageId = "",
+            messages = mutableListOf(),
+            id = "${ticker++}")
+    mockMessageHistory.add(messageHistory)
+
+    return Resource.Success(messageHistory)
+  }
+}

--- a/app/src/main/java/com/github/se/eventradar/model/repository/message/MockMessageRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/message/MockMessageRepository.kt
@@ -3,7 +3,6 @@ package com.github.se.eventradar.model.repository.message
 import com.github.se.eventradar.model.Resource
 import com.github.se.eventradar.model.message.Message
 import com.github.se.eventradar.model.message.MessageHistory
-import java.time.LocalDateTime
 
 class MockMessageRepository : IMessageRepository {
   private val mockMessageHistory = mutableListOf<MessageHistory>()
@@ -12,8 +11,7 @@ class MockMessageRepository : IMessageRepository {
   override suspend fun getMessages(user1: String, user2: String): Resource<MessageHistory> {
     val messageHistory =
         mockMessageHistory.find {
-          (it.fromUser == user1 && it.toUser == user2) ||
-              (it.fromUser == user2 && it.toUser == user1)
+          (it.user1 == user1 && it.user2 == user2) || (it.user1 == user2 && it.user2 == user1)
         }
 
     return if (messageHistory != null) {
@@ -46,10 +44,7 @@ class MockMessageRepository : IMessageRepository {
             .find { it.id == messageHistory.id }
             ?.messages
             ?.find { it.id == message.id }
-            ?.let {
-              it.isRead = true
-              it.dateTimeSent = LocalDateTime.parse("2021-01-01T00:00:00")
-            }
+            ?.let { it.isRead = true }
 
     return if (updateMessage != null) {
       Resource.Success(Unit)
@@ -66,8 +61,8 @@ class MockMessageRepository : IMessageRepository {
   ): Resource<MessageHistory> {
     val messageHistory =
         MessageHistory(
-            fromUser = user1,
-            toUser = user2,
+            user1 = user1,
+            user2 = user2,
             latestMessageId = "",
             messages = mutableListOf(),
             id = "${ticker++}")

--- a/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
@@ -35,8 +35,8 @@ class MockMessageRepositoryUnitTest {
 
     messageHistory = messageHistory as Resource.Success
 
-    assert(messageHistory.data.fromUser == "1")
-    assert(messageHistory.data.toUser == "2")
+    assert(messageHistory.data.user1 == "1")
+    assert(messageHistory.data.user2 == "2")
   }
 
   @Test
@@ -106,8 +106,8 @@ class MockMessageRepositoryUnitTest {
 
     messageHistory = messageHistory as Resource.Success
 
-    assert(messageHistory.data.fromUser == "1")
-    assert(messageHistory.data.toUser == "3")
+    assert(messageHistory.data.user1 == "1")
+    assert(messageHistory.data.user2 == "3")
   }
 
   @Test

--- a/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
@@ -1,0 +1,181 @@
+package com.github.se.eventradar
+
+import com.github.se.eventradar.model.Resource
+import com.github.se.eventradar.model.message.Message
+import com.github.se.eventradar.model.message.MessageHistory
+import com.github.se.eventradar.model.repository.message.IMessageRepository
+import com.github.se.eventradar.model.repository.message.MockMessageRepository
+import java.time.LocalDateTime
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class MockMessageRepositoryUnitTest {
+  private lateinit var messageRepository: IMessageRepository
+
+  private val mockMessage =
+      Message(
+          sender = "1",
+          content = "Hello",
+          dateTimeSent = LocalDateTime.parse("2021-01-01T00:00:00"),
+          isRead = false,
+          id = "1")
+
+  @Before
+  fun setUp() {
+    messageRepository = MockMessageRepository()
+  }
+
+  @Test
+  fun testGetMessagesCreatesNewMessageHistoryAtConstruction() = runTest {
+    // Test getMessages() method
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    assert(messageHistory.data.fromUser == "1")
+    assert(messageHistory.data.toUser == "2")
+  }
+
+  @Test
+  fun testGetMessagesReturnsAlreadyCreatedMessageHistory() = runTest {
+    // Test getMessages() method
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    val messageHistoryId = messageHistory.data.id
+
+    messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    assert((messageHistory as Resource.Success).data.id == messageHistoryId)
+  }
+
+  @Test
+  fun testAddMessage() = runTest {
+    // Test addMessage() method
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
+
+    assert(addMessage is Resource.Success)
+
+    assert(messageHistory.data.messages[0] == mockMessage)
+    assert(messageHistory.data.latestMessageId == "1")
+  }
+
+  @Test
+  fun testUpdateMessage() = runTest {
+    // Test updateMessage() method
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
+
+    assert(addMessage is Resource.Success)
+
+    val updateMessage = messageRepository.updateMessageToReadState(mockMessage, messageHistory.data)
+
+    assert(updateMessage is Resource.Success)
+
+    assert(messageHistory.data.messages[0].isRead)
+    assert(
+        messageHistory.data.messages[0].dateTimeSent == LocalDateTime.parse("2021-01-01T00:00:00"))
+    assert(messageHistory.data.messages[0].id == "1")
+  }
+
+  @Test
+  fun testCreateNewMessageHistory() = runTest {
+    // Test createNewMessageHistory() method
+    var messageHistory = messageRepository.createNewMessageHistory("1", "3")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    assert(messageHistory.data.fromUser == "1")
+    assert(messageHistory.data.toUser == "3")
+  }
+
+  @Test
+  fun addMessageToNonExistentMessageHistory() = runTest {
+    // Test addMessage() method
+    val id = "50"
+    val addMessage =
+        messageRepository.addMessage(
+            mockMessage, MessageHistory("1", "2", "1", mutableListOf(), id = id))
+
+    assert(addMessage is Resource.Failure)
+    assert(
+        (addMessage as Resource.Failure).throwable.message ==
+            "MessageHistory with id $id not found")
+  }
+
+  @Test
+  fun updateMessageInNonExistentMessageHistory() = runTest {
+    // Test updateMessage() method
+    val id = "50"
+    val updateMessage =
+        messageRepository.updateMessageToReadState(
+            mockMessage, MessageHistory("1", "2", "1", mutableListOf(), id = id))
+
+    assert(updateMessage is Resource.Failure)
+    assert(
+        (updateMessage as Resource.Failure).throwable.message ==
+            "Message with id 1 not found in MessageHistory with id $id")
+  }
+
+  @Test
+  fun updateNonExistentMessageInValidMessageHistory() = runTest {
+    // Test updateMessage() method
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    val updateMessage = messageRepository.updateMessageToReadState(mockMessage, messageHistory.data)
+
+    assert(updateMessage is Resource.Failure)
+    assert(
+        (updateMessage as Resource.Failure).throwable.message ==
+            "Message with id 1 not found in MessageHistory with id ${messageHistory.data.id}")
+  }
+
+  @Test
+  fun addMessageUpdatesMessageHistoryWhenNewMessageIsReceived() = runTest {
+    var messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    messageHistory = messageHistory as Resource.Success
+
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
+
+    assert(addMessage is Resource.Success)
+
+    val addSecondMessage =
+        messageRepository.addMessage(mockMessage.copy(id = "2"), messageHistory.data)
+
+    assert(addSecondMessage is Resource.Success)
+
+    messageHistory = messageRepository.getMessages("1", "2")
+
+    assert(messageHistory is Resource.Success)
+
+    assert((messageHistory as Resource.Success).data.latestMessageId == "2")
+  }
+}


### PR DESCRIPTION
## Objective
- Create a messages repository using dependency injection, following the structure outlined in #92

## Key Changes
- [ ] Create the `IMessageRepository` interface with two implementations
- [ ] Query the Firebase database to add and update messages, and create new message histories
- [ ] Create an mock (in-memory) database for testing purposes
- [ ] Create a test suite for the mock database
- [ ] add a `@TestInstallsIn` annotated module to tell Hilt to automatically use the mock database in tests

related to #91 