### PR TITLE
Hosted Events ViewModel + Tests

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -2,8 +2,6 @@ package com.github.se.eventradar.home
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.eventradar.viewmodel.EventsOverviewUiState
-import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.model.Location
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
@@ -12,6 +10,8 @@ import com.github.se.eventradar.model.event.EventTicket
 import com.github.se.eventradar.screens.HomeScreen
 import com.github.se.eventradar.ui.home.HomeScreen
 import com.github.se.eventradar.ui.navigation.NavigationActions
+import com.github.se.eventradar.viewmodel.EventsOverviewUiState
+import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -60,8 +60,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
                             attendeeList = setOf("Test Attendee"),
                             category = EventCategory.COMMUNITY,
                             fireBaseID = "$it")
-                      }))
-      )
+                      })))
 
   @Before
   fun testSetup() {

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -2,8 +2,8 @@ package com.github.se.eventradar.home
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.eventradar.model.EventsOverviewUiState
-import com.github.se.eventradar.model.EventsOverviewViewModel
+import com.github.se.eventradar.viewmodel.EventsOverviewUiState
+import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.model.Location
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
@@ -60,7 +60,8 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
                             attendeeList = setOf("Test Attendee"),
                             category = EventCategory.COMMUNITY,
                             fireBaseID = "$it")
-                      })))
+                      }))
+      )
 
   @Before
   fun testSetup() {

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -53,7 +53,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.github.se.eventradar.R
-import com.github.se.eventradar.model.EventsOverviewViewModel
+import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.repository.event.MockEventRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -53,7 +53,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.github.se.eventradar.R
-import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.repository.event.MockEventRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository
@@ -61,6 +60,7 @@ import com.github.se.eventradar.ui.BottomNavigationMenu
 import com.github.se.eventradar.ui.map.EventMap
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 
 @Composable
 fun HomeScreen(

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
@@ -13,6 +13,7 @@ import java.time.ZoneId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+//new branch
 class EventDetailsViewModel(
     private val db: FirebaseFirestore = Firebase.firestore,
     eventId: String

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
@@ -13,7 +13,6 @@ import java.time.ZoneId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-//new branch
 class EventDetailsViewModel(
     private val db: FirebaseFirestore = Firebase.firestore,
     eventId: String

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventDetailsViewModel.kt
@@ -1,7 +1,9 @@
-package com.github.se.eventradar.model.event
+package com.github.se.eventradar.viewmodel
 
 import androidx.lifecycle.ViewModel
 import com.github.se.eventradar.model.Location
+import com.github.se.eventradar.model.event.EventCategory
+import com.github.se.eventradar.model.event.EventTicket
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -44,7 +44,7 @@ constructor(
         is Resource.Success -> {
           val user = userResponse.data!!
           val attendeeList = user.eventsAttendeeList
-          if (attendeeList.isNotEmpty()) {
+          if (attendeeList.isNotEmpty()) { //will it ever be that
             when (val events = eventRepository.getEventsByIds(attendeeList)) {
               is Resource.Success -> {
                 _uiState.value =
@@ -76,7 +76,7 @@ constructor(
 
 data class EventsOverviewUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
-    var viewType: ViewType = ViewType.LIST,
+    var viewList: Boolean = true,
     var tab: Tab = Tab.BROWSE,
     val searchQuery: String = "",
 )

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -76,5 +76,12 @@ constructor(
 
 data class EventsOverviewUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
+    var viewType: ViewType = ViewType.LIST,
+    var tab: Tab = Tab.BROWSE,
     val searchQuery: String = "",
 )
+
+enum class Tab {
+    BROWSE,
+    UPCOMING_EVENTS
+}

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -1,8 +1,9 @@
-package com.github.se.eventradar.model
+package com.github.se.eventradar.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.se.eventradar.model.Resource
 import com.github.se.eventradar.model.event.EventList
 import com.github.se.eventradar.model.repository.event.IEventRepository
 import com.github.se.eventradar.model.repository.user.IUserRepository

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -82,6 +82,6 @@ data class EventsOverviewUiState(
 )
 
 enum class Tab {
-    BROWSE,
-    UPCOMING_EVENTS
+  BROWSE,
+  UPCOMING_EVENTS
 }

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -44,7 +44,7 @@ constructor(
         is Resource.Success -> {
           val user = userResponse.data!!
           val attendeeList = user.eventsAttendeeList
-          if (attendeeList.isNotEmpty()) { //will it ever be that
+          if (attendeeList.isNotEmpty()) { // will it ever be that
             when (val events = eventRepository.getEventsByIds(attendeeList)) {
               is Resource.Success -> {
                 _uiState.value =

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-//new branch
 @HiltViewModel
 class EventsOverviewViewModel
 @Inject

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
@@ -15,38 +15,23 @@ import kotlinx.coroutines.launch
 
 //new branch
 @HiltViewModel
-class EventsOverviewViewModel
+class HostedEventsViewModel
 @Inject
 constructor(
     private val eventRepository: IEventRepository,
     private val userRepository: IUserRepository
 ) : ViewModel() {
-  private val _uiState = MutableStateFlow(EventsOverviewUiState())
-  val uiState: StateFlow<EventsOverviewUiState> = _uiState
+  private val _uiState = MutableStateFlow(HostedEventsUiState())
+  val uiState: StateFlow<HostedEventsUiState> = _uiState
 
-  fun getEvents() {
-    viewModelScope.launch {
-      when (val response = eventRepository.getEvents()) {
-        is Resource.Success -> {
-          _uiState.value =
-              _uiState.value.copy(
-                  eventList =
-                      EventList(
-                          response.data, response.data, _uiState.value.eventList.selectedEvent))
-        }
-        is Resource.Failure -> Log.d("EventsOverviewViewModel", "Error getting events")
-      }
-    }
-  }
-
-  fun getUpcomingEvents(uid: String) {
+  fun getHostedEvents(uid: String) {
     viewModelScope.launch {
       when (val userResponse = userRepository.getUser(uid)) {
         is Resource.Success -> {
           val user = userResponse.data!!
-          val attendeeList = user.eventsAttendeeList
-          if (attendeeList.isNotEmpty()) {
-            when (val events = eventRepository.getEventsByIds(attendeeList)) {
+          val eventsHostList = user.eventsHostList
+          if (eventsHostList.isNotEmpty()) {
+            when (val events = eventRepository.getEventsByIds(eventsHostList)) {
               is Resource.Success -> {
                 _uiState.value =
                     _uiState.value.copy(
@@ -55,7 +40,7 @@ constructor(
                                 events.data, events.data, _uiState.value.eventList.selectedEvent))
               }
               is Resource.Failure -> {
-                Log.d("EventsOverviewViewModel", "Error getting events for $uid")
+                Log.d("HostedEventsViewModel", "Error getting hosted events for $uid")
                 _uiState.value =
                     _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
               }
@@ -66,7 +51,7 @@ constructor(
           }
         }
         is Resource.Failure -> {
-          Log.d("EventsOverviewViewModel", "Error fetching user document")
+          Log.d("HostedEventsViewModel", "Error fetching user document")
           _uiState.value =
               _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
         }
@@ -75,7 +60,8 @@ constructor(
   }
 }
 
-data class EventsOverviewUiState(
+data class HostedEventsUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
+    var viewType: ViewType = ViewType.LIST,
     val searchQuery: String = "",
 )

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
@@ -61,6 +61,6 @@ constructor(
 
 data class HostedEventsUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
-    var viewType: ViewType = ViewType.LIST,
+    var viewList: Boolean = true,
     val searchQuery: String = "",
 )

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-//new branch
 @HiltViewModel
 class HostedEventsViewModel
 @Inject

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
@@ -1,0 +1,7 @@
+package com.github.se.eventradar.viewmodel
+
+//new branch
+enum class ViewType {
+  LIST,
+  MAP
+}

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
@@ -1,6 +1,0 @@
-package com.github.se.eventradar.viewmodel
-
-enum class ViewType {
-  LIST,
-  MAP
-}

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/ReusableEnums.kt
@@ -1,6 +1,5 @@
 package com.github.se.eventradar.viewmodel
 
-//new branch
 enum class ViewType {
   LIST,
   MAP

--- a/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
@@ -9,6 +9,7 @@ import com.github.se.eventradar.model.repository.event.IEventRepository
 import com.github.se.eventradar.model.repository.event.MockEventRepository
 import com.github.se.eventradar.model.repository.user.IUserRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository
+import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockkStatic

--- a/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-//new branch
 @ExperimentalCoroutinesApi
 class HostedEventsViewModelTest {
   private lateinit var viewModel: HostedEventsViewModel

--- a/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
@@ -1,0 +1,159 @@
+package com.github.se.eventradar
+
+import android.util.Log
+import com.github.se.eventradar.model.Location
+import com.github.se.eventradar.model.User
+import com.github.se.eventradar.model.event.Event
+import com.github.se.eventradar.model.event.EventCategory
+import com.github.se.eventradar.model.event.EventTicket
+import com.github.se.eventradar.model.repository.event.IEventRepository
+import com.github.se.eventradar.model.repository.event.MockEventRepository
+import com.github.se.eventradar.model.repository.user.IUserRepository
+import com.github.se.eventradar.model.repository.user.MockUserRepository
+import com.github.se.eventradar.viewmodel.HostedEventsViewModel
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.time.LocalDateTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+//new branch
+@ExperimentalCoroutinesApi
+class HostedEventsViewModelTest {
+  private lateinit var viewModel: HostedEventsViewModel
+  private lateinit var eventRepository: IEventRepository
+  private lateinit var userRepository: IUserRepository
+
+  class MainDispatcherRule(
+      private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+  ) : TestWatcher() {
+    override fun starting(description: Description) {
+      Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+      Dispatchers.resetMain()
+    }
+  }
+
+  @get:Rule val mainDispatcherRule = MainDispatcherRule()
+
+  private val mockEvent =
+      Event(
+          eventName = "Event 1",
+          eventPhoto = "",
+          start = LocalDateTime.now(),
+          end = LocalDateTime.now(),
+          location = Location(0.0, 0.0, "Test Location"),
+          description = "Test Description",
+          ticket = EventTicket("Test Ticket", 0.0, 1),
+          contact = "Test Contact Email",
+          organiserList = setOf("userid1"),
+          attendeeList = setOf("Test Attendee"),
+          category = EventCategory.COMMUNITY,
+          fireBaseID = "eventId1")
+
+  private val mockUser =
+      User(
+          userId = "userid1",
+          age = 30,
+          email = "test@example.com",
+          firstName = "John",
+          lastName = "Doe",
+          phoneNumber = "1234567890",
+          accountStatus = "active",
+          eventsAttendeeList = listOf("userId1", "userId2"),
+          eventsHostList = listOf(),
+          profilePicUrl = "http://example.com/pic.jpg",
+          qrCodeUrl = "http://example.com/qr.jpg",
+          username = "john_doe")
+
+  @Before
+  fun setUp() {
+    eventRepository = MockEventRepository()
+    userRepository = MockUserRepository()
+    viewModel = HostedEventsViewModel(eventRepository, userRepository)
+  }
+
+  @Test
+  fun testGetHostedEventsEmpty() = runTest {
+    userRepository.addUser(mockUser)
+    viewModel.getHostedEvents(mockUser.userId)
+    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
+    Assert.assertNull(viewModel.uiState.value.eventList.selectedEvent)
+  }
+
+  @Test
+  fun testGetHostedEventsSuccess() = runTest {
+    val events =
+        listOf(
+            mockEvent.copy(fireBaseID = "eventId1"),
+            mockEvent.copy(fireBaseID = "eventId2"),
+            mockEvent.copy(fireBaseID = "eventId3"))
+    events.forEach { event -> eventRepository.addEvent(event) }
+
+    val listOfEventIds = events.map { event -> event.fireBaseID }
+    val userWithHostedEvent = mockUser.copy(eventsHostList = listOfEventIds)
+    userRepository.addUser(userWithHostedEvent)
+
+    viewModel.getHostedEvents(userWithHostedEvent.userId)
+    assert(viewModel.uiState.value.eventList.allEvents.isNotEmpty())
+    assert(viewModel.uiState.value.eventList.allEvents.size == 3)
+    assert(
+        viewModel.uiState.value.eventList.allEvents.containsAll(events)) // this is where it fails.
+    assert(viewModel.uiState.value.eventList.filteredEvents.size == 3)
+    assert(viewModel.uiState.value.eventList.filteredEvents.containsAll(events))
+    Assert.assertNull(viewModel.uiState.value.eventList.selectedEvent)
+  }
+
+  @Test
+  fun testGetHostedEventsWithEventsNotInRepo() = runTest {
+    mockkStatic(Log::class)
+    every { Log.d(any(), any()) } returns 0
+    val events =
+        listOf(
+            mockEvent.copy(fireBaseID = "eventId1"),
+            mockEvent.copy(fireBaseID = "eventId2"),
+            mockEvent.copy(fireBaseID = "eventId3"))
+    // event is not added to repo.
+    val listOfEventIds = events.map { event -> event.fireBaseID }
+    val userWithHostedEvent = mockUser.copy(eventsHostList = listOfEventIds)
+    userRepository.addUser(userWithHostedEvent)
+    viewModel.getHostedEvents(userWithHostedEvent.userId)
+    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
+    Assert.assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    verify {
+      Log.d(
+          "HostedEventsViewModel", "Error getting hosted events for ${userWithHostedEvent.userId}")
+    }
+    confirmVerified()
+  }
+
+  @Test
+  fun testGetHostedEventsUserNotFound() = runTest {
+    mockkStatic(Log::class)
+    every { Log.d(any(), any()) } returns 0
+    val userId = "userNotFound"
+    viewModel.getHostedEvents(userId)
+    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
+    Assert.assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    verify { Log.d("HostedEventsViewModel", "Error fetching user document") }
+    confirmVerified()
+  }
+}


### PR DESCRIPTION
Related to #109 => closes #109 
## Objective
- Create a ViewModel for User's Hosted Events

## Changes made
- Created a new package for viewmodels for better separation of classes
- Created HostedEventsViewModel and HostedEventsViewModelTest to test the functionality
- Added Enum file for Map view/List View and Upcoming/Browse Events Tab to be used in the viewModel
- ViewModel now handles all state changes in Home.kt UI and Hosting.kt UI

Notes:
- This is a commit just for the ViewModel, thus all the UI changes for Hosting.kt in order to utilize the new ViewModel which keeps the Map/List View Type and the Upcoming/Browse Tab will be made in the HostedEventsUI PR After this.