### PR TITLE
Exclude Previews from Code Coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,7 +186,6 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         "**/*Test*.*",
         "android/**/*.*",
         "**/SignatureChecks.*",
-        "**/*Preview*.*",
     )
     val debugTree = fileTree("${project.buildDir}/tmp/kotlin-classes/debug") {
         exclude(fileFilter)

--- a/app/src/main/java/com/github/se/eventradar/ExcludeFromJacocoGeneratedReport.kt
+++ b/app/src/main/java/com/github/se/eventradar/ExcludeFromJacocoGeneratedReport.kt
@@ -1,0 +1,5 @@
+package com.github.se.eventradar
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ExcludeFromJacocoGeneratedReport

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
+import com.github.se.eventradar.ExcludeFromJacocoGeneratedReport
 import com.github.se.eventradar.R
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
@@ -471,6 +472,7 @@ fun EventCard(event: Event) {
 }
 
 @Preview(showBackground = true, showSystemUi = true)
+@ExcludeFromJacocoGeneratedReport
 @Composable
 fun HomeScreenPreview() {
   val mockEventRepo = MockEventRepository()

--- a/app/src/main/java/com/github/se/eventradar/ui/login/SignUpScreen.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/login/SignUpScreen.kt
@@ -55,6 +55,7 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberImagePainter
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
+import com.github.se.eventradar.ExcludeFromJacocoGeneratedReport
 import com.github.se.eventradar.R
 import com.github.se.eventradar.model.repository.user.MockUserRepository
 import com.github.se.eventradar.ui.navigation.NavigationActions
@@ -322,6 +323,7 @@ fun PhoneNumberInput(
 }
 
 @Preview
+@ExcludeFromJacocoGeneratedReport
 @Composable
 fun PreviewSignUpScreen() {
   SignUpScreen(LoginViewModel(MockUserRepository()), NavigationActions(rememberNavController()))


### PR DESCRIPTION
## Objectives
- exclude preview functions from code coverage

## Key Changes
- defined a new annotation to annotate preview files (see [here](https://stackoverflow.com/questions/47824761/how-would-i-add-an-annotation-to-exclude-a-method-from-a-jacoco-code-coverage-re))
- annotate all preview files currently in main with this annotation

