### PR TITLE
Change app manifest name to `Event Radar`

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">My Application</string>
+    <string name="app_name">Event Radar</string>
     <string name="web_client_id">1043895872028–8m8f4kpcmqe60ofkef734vbgqph8g5ut.apps.googleusercontent.com</string>
     <string name="default_web_client_id" translatable="false">webClientId.apps.googleusercontent.com</string>
     <string name="test1">test1</string>


### PR DESCRIPTION
## Key Changes
- update the app manifest to have `Event Radar` as app name instead of `My Application`