### PR TITLE
Force workflow to run on all release branches

### DIFF
--- a/.github/workflows/generate-apk-aab-debug-release.yml
+++ b/.github/workflows/generate-apk-aab-debug-release.yml
@@ -5,10 +5,9 @@ env:
   main_project_module: app
 
 on:
-
   push:
     branches:
-      - 'release/**'
+      - 'M*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
All release branches have the convention of "M*", where * corresponds to the milestone number.