### PR TITLE
Refactor HostedEventsViewModel to Use getCurrentUserId()

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/hosting/HostingTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/hosting/HostingTest.kt
@@ -61,7 +61,7 @@ class HostingTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
 
   @Before
   fun testSetup() {
-    every { mockHostedEventsViewModel.getHostedEvents(any()) } returns Unit
+    every { mockHostedEventsViewModel.getHostedEvents() } returns Unit
     every { mockHostedEventsViewModel.uiState } returns sampleEventList
     composeTestRule.setContent {
       HostingScreen(viewModel = mockHostedEventsViewModel, navigationActions = mockNavActions)
@@ -116,7 +116,7 @@ class HostingTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSup
   @Test
   fun getHostedEventsIsCalledOnLaunch() = run {
     onComposeScreen<HostingScreen>(composeTestRule) {
-      verify(exactly = 1) { mockHostedEventsViewModel.getHostedEvents(any()) }
+      verify(exactly = 1) { mockHostedEventsViewModel.getHostedEvents() }
       verify(exactly = 1) { mockHostedEventsViewModel.uiState }
       confirmVerified(mockHostedEventsViewModel)
     }

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/HostedEventsViewModel.kt
@@ -7,8 +7,6 @@ import com.github.se.eventradar.model.Resource
 import com.github.se.eventradar.model.event.EventList
 import com.github.se.eventradar.model.repository.event.IEventRepository
 import com.github.se.eventradar.model.repository.user.IUserRepository
-import com.google.firebase.Firebase
-import com.google.firebase.auth.auth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,41 +23,52 @@ constructor(
   private val _uiState = MutableStateFlow(HostedEventsUiState())
   val uiState: StateFlow<HostedEventsUiState> = _uiState
 
-  fun getHostedEvents(uid: String? = Firebase.auth.currentUser?.uid) {
-    if (uid == null) {
-      Log.d("HostedEventsViewModel", "User not logged in")
-    } else {
-      viewModelScope.launch {
-        when (val userResponse = userRepository.getUser(uid)) {
+  fun getHostedEvents() {
+    viewModelScope.launch {
+      userRepository.getCurrentUserId().let { userIdResource ->
+        when (userIdResource) {
           is Resource.Success -> {
-            val user = userResponse.data!!
-            val eventsHostSet = user.eventsHostSet
-            if (eventsHostSet.isNotEmpty()) {
-              when (val events = eventRepository.getEventsByIds(eventsHostSet.toList())) {
-                is Resource.Success -> {
-                  _uiState.value =
-                      _uiState.value.copy(
-                          eventList =
-                              EventList(
-                                  events.data, events.data, _uiState.value.eventList.selectedEvent))
-                }
-                is Resource.Failure -> {
-                  Log.d("HostedEventsViewModel", "Error getting hosted events for $uid")
-                  _uiState.value =
-                      _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
-                }
-              }
-            } else {
-              _uiState.value =
-                  _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
-            }
+            val uid = userIdResource.data
+            getUserHostedEvents(uid)
           }
           is Resource.Failure -> {
-            Log.d("HostedEventsViewModel", "Error fetching user document")
+            Log.d("HostedEventsViewModel", "User not logged in or error fetching user ID")
             _uiState.value =
                 _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
           }
         }
+      }
+    }
+  }
+
+  private suspend fun getUserHostedEvents(uid: String) {
+    when (val userResponse = userRepository.getUser(uid)) {
+      is Resource.Success -> {
+        val user = userResponse.data!!
+        val eventsHostSet = user.eventsHostSet
+        if (eventsHostSet.isNotEmpty()) {
+          when (val events = eventRepository.getEventsByIds(eventsHostSet.toList())) {
+            is Resource.Success -> {
+              _uiState.value =
+                  _uiState.value.copy(
+                      eventList =
+                          EventList(
+                              events.data, events.data, _uiState.value.eventList.selectedEvent))
+            }
+            is Resource.Failure -> {
+              Log.d("HostedEventsViewModel", "Error getting hosted events for $uid")
+              _uiState.value =
+                  _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+            }
+          }
+        } else {
+          _uiState.value =
+              _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+        }
+      }
+      is Resource.Failure -> {
+        Log.d("HostedEventsViewModel", "Error fetching user document")
+        _uiState.value = _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
       }
     }
   }


### PR DESCRIPTION
### Key Changes: 

- Refactored HostedEventsViewModel to utilize the new getCurrentUserId() method from IUserRepository, replacing direct Firebase authentication calls.

- Updated associated tests to align with the new implementation.