### PR TITLE
Refine Event Handling on Home Screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -143,32 +143,46 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   }
 
   @Test
-  fun testUpcomingEventsTriggeredOnTabSelect() = run {
+  fun testTriggeredOnTabSelect() = run {
     onComposeScreen<HomeScreen>(composeTestRule) {
-      step("Select 'Upcoming' tab") {
-        upcomingTab {
-          assertIsDisplayed()
-          performClick()
+        step("Select 'Upcoming' tab") {
+            upcomingTab {
+                assertIsDisplayed()
+                performClick()
+            }
         }
-      }
+        // Update the UI state to reflect the change
+        sampleEventList.value = sampleEventList.value.copy(tab = Tab.UPCOMING)
+
+        // Verify if getEvents is called upon init
+        verify { mockEventsOverviewViewModel.getEvents() }
+
+        // Verify that the tab change is handled correctly
+        verify { mockEventsOverviewViewModel.onTabChanged(Tab.UPCOMING, any()) }
+
+        // Verify that the upcoming events are fetched once
+        verify(exactly = 1) { mockEventsOverviewViewModel.getUpcomingEvents() }
+
+        // Check that uiState is accessed as expected
+        verify { mockEventsOverviewViewModel.uiState }
+
+        step("Select 'Browse' tab") {
+            browseTab {
+                assertIsDisplayed()
+                performClick()
+            }
+        }
+        sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
+
+        // Verify if getEvents is called upon init
+        verify { mockEventsOverviewViewModel.getEvents() }
+
+        // Verify that the tab change is handled correctly
+        verify { mockEventsOverviewViewModel.onTabChanged(Tab.BROWSE, any()) }
+
+        // Confirm that no unexpected interactions have occurred
+        confirmVerified(mockEventsOverviewViewModel)
     }
-    // Update the UI state to reflect the change
-    sampleEventList.value = sampleEventList.value.copy(tab = Tab.UPCOMING)
-
-    // Verify if getEvents is called upon init
-    verify { mockEventsOverviewViewModel.getEvents() }
-
-    // Verify that the tab change is handled correctly
-    verify { mockEventsOverviewViewModel.onTabChanged(Tab.UPCOMING, any()) }
-
-    // Verify that the upcoming events are fetched once
-    verify(exactly = 1) { mockEventsOverviewViewModel.getUpcomingEvents() }
-
-    // Check that uiState is accessed as expected
-    verify { mockEventsOverviewViewModel.uiState }
-
-    // Confirm that no unexpected interactions have occurred
-    confirmVerified(mockEventsOverviewViewModel)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -134,11 +134,28 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
 
   @Test
   fun getEventsIsCalledOnLaunch() = run {
-    sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
     onComposeScreen<HomeScreen>(composeTestRule) {
       verify(exactly = 1) { mockEventsOverviewViewModel.getEvents() }
       verify(exactly = 1) { mockEventsOverviewViewModel.uiState }
       confirmVerified(mockEventsOverviewViewModel)
+    }
+  }
+
+  @Test
+  fun getUpcomingEventsIsCalledOnRecomposition() = run {
+    sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
+    onComposeScreen<HomeScreen>(composeTestRule) {
+      step("Select 'Upcoming' tab") {
+        upcomingTab {
+          assertIsDisplayed()
+          performClick()
+        }
+      }
+      sampleEventList.value = sampleEventList.value.copy(tab = Tab.UPCOMING)
+    }
+    onComposeScreen<HomeScreen>(composeTestRule) {
+      verify(exactly = 1) { mockEventsOverviewViewModel.getUpcomingEvents() }
+      verify(exactly = 1) { mockEventsOverviewViewModel.uiState }
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -134,7 +134,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
 
   @Test
   fun getEventsIsCalledOnLaunch() = run {
-      sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
+    sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
     onComposeScreen<HomeScreen>(composeTestRule) {
       verify(exactly = 1) { mockEventsOverviewViewModel.getEvents() }
       verify(exactly = 1) { mockEventsOverviewViewModel.uiState }
@@ -175,8 +175,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testDisplayUpcomingEventsList() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(
-            eventList = EventList(allEvents = upcomingEvents), userLoggedIn = true)
+        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -199,8 +198,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testDisplayUpcomingEventsMap() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(
-            eventList = EventList(allEvents = upcomingEvents), userLoggedIn = true)
+        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -223,8 +221,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testPleaseLogInMessageDisplayed() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(
-            eventList = EventList(allEvents = upcomingEvents), userLoggedIn = false)
+        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = false)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -249,7 +246,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testNoUpcomingEventsMessageDisplayed() = run {
     sampleEventList.value =
         sampleEventList.value.copy(
-            eventList = EventList(emptyList(), emptyList(), null), viewList = true, userLoggedIn = true)
+            upcomingEvents = emptyList(), viewList = true, userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -134,6 +134,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
 
   @Test
   fun getEventsIsCalledOnLaunch() = run {
+      sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
     onComposeScreen<HomeScreen>(composeTestRule) {
       verify(exactly = 1) { mockEventsOverviewViewModel.getEvents() }
       verify(exactly = 1) { mockEventsOverviewViewModel.uiState }

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -175,7 +175,8 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testDisplayUpcomingEventsList() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = true)
+        sampleEventList.value.copy(
+            upcomingEventList = EventList(allEvents = upcomingEvents), userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -198,7 +199,8 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testDisplayUpcomingEventsMap() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = true)
+        sampleEventList.value.copy(
+            upcomingEventList = EventList(allEvents = upcomingEvents), userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -221,7 +223,8 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testPleaseLogInMessageDisplayed() = run {
     val upcomingEvents = listOf(mockEvent, mockEvent.copy(fireBaseID = "2"))
     sampleEventList.value =
-        sampleEventList.value.copy(upcomingEvents = upcomingEvents, userLoggedIn = false)
+        sampleEventList.value.copy(
+            upcomingEventList = EventList(allEvents = upcomingEvents), userLoggedIn = false)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {
@@ -246,7 +249,9 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testNoUpcomingEventsMessageDisplayed() = run {
     sampleEventList.value =
         sampleEventList.value.copy(
-            upcomingEvents = emptyList(), viewList = true, userLoggedIn = true)
+            upcomingEventList = EventList(emptyList(), emptyList(), null),
+            viewList = true,
+            userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -145,43 +145,43 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   @Test
   fun testTriggeredOnTabSelect() = run {
     onComposeScreen<HomeScreen>(composeTestRule) {
-        step("Select 'Upcoming' tab") {
-            upcomingTab {
-                assertIsDisplayed()
-                performClick()
-            }
+      step("Select 'Upcoming' tab") {
+        upcomingTab {
+          assertIsDisplayed()
+          performClick()
         }
-        // Update the UI state to reflect the change
-        sampleEventList.value = sampleEventList.value.copy(tab = Tab.UPCOMING)
+      }
+      // Update the UI state to reflect the change
+      sampleEventList.value = sampleEventList.value.copy(tab = Tab.UPCOMING)
 
-        // Verify if getEvents is called upon init
-        verify { mockEventsOverviewViewModel.getEvents() }
+      // Verify if getEvents is called upon init
+      verify { mockEventsOverviewViewModel.getEvents() }
 
-        // Verify that the tab change is handled correctly
-        verify { mockEventsOverviewViewModel.onTabChanged(Tab.UPCOMING, any()) }
+      // Verify that the tab change is handled correctly
+      verify { mockEventsOverviewViewModel.onTabChanged(Tab.UPCOMING, any()) }
 
-        // Verify that the upcoming events are fetched once
-        verify(exactly = 1) { mockEventsOverviewViewModel.getUpcomingEvents() }
+      // Verify that the upcoming events are fetched once
+      verify(exactly = 1) { mockEventsOverviewViewModel.getUpcomingEvents() }
 
-        // Check that uiState is accessed as expected
-        verify { mockEventsOverviewViewModel.uiState }
+      // Check that uiState is accessed as expected
+      verify { mockEventsOverviewViewModel.uiState }
 
-        step("Select 'Browse' tab") {
-            browseTab {
-                assertIsDisplayed()
-                performClick()
-            }
+      step("Select 'Browse' tab") {
+        browseTab {
+          assertIsDisplayed()
+          performClick()
         }
-        sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
+      }
+      sampleEventList.value = sampleEventList.value.copy(tab = Tab.BROWSE)
 
-        // Verify if getEvents is called upon init
-        verify { mockEventsOverviewViewModel.getEvents() }
+      // Verify if getEvents is called upon init
+      verify { mockEventsOverviewViewModel.getEvents() }
 
-        // Verify that the tab change is handled correctly
-        verify { mockEventsOverviewViewModel.onTabChanged(Tab.BROWSE, any()) }
+      // Verify that the tab change is handled correctly
+      verify { mockEventsOverviewViewModel.onTabChanged(Tab.BROWSE, any()) }
 
-        // Confirm that no unexpected interactions have occurred
-        confirmVerified(mockEventsOverviewViewModel)
+      // Confirm that no unexpected interactions have occurred
+      confirmVerified(mockEventsOverviewViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -249,7 +249,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
   fun testNoUpcomingEventsMessageDisplayed() = run {
     sampleEventList.value =
         sampleEventList.value.copy(
-            eventList = EventList(emptyList(), emptyList(), null), userLoggedIn = true)
+            eventList = EventList(emptyList(), emptyList(), null), viewList = true, userLoggedIn = true)
 
     onComposeScreen<HomeScreen>(composeTestRule) {
       step("Trigger loading of upcoming events") {

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -57,10 +57,12 @@ fun HomeScreen(
   // Ui States handled by viewModel
   val uiState by viewModel.uiState.collectAsState()
 
-  LaunchedEffect(Unit) { when{
+  LaunchedEffect(Unit) {
+    when {
       (uiState.tab == Tab.BROWSE) -> viewModel.getEvents()
       else -> viewModel.getUpcomingEvents()
-  }  }
+    }
+  }
 
   ConstraintLayout(modifier = Modifier.fillMaxSize().testTag("homeScreen")) {
     val (logo, tabs, searchAndFilter, filterPopUp, eventList, eventMap, bottomNav, viewToggle) =
@@ -186,7 +188,7 @@ fun HomeScreen(
                       start.linkTo(parent.start)
                       end.linkTo(parent.end)
                     })
-        (uiState.viewList && uiState.eventList.allEvents.isEmpty()) ->
+        (uiState.viewList && uiState.upcomingEvents.isEmpty()) ->
             Text(
                 "You have no upcoming events",
                 modifier =
@@ -197,7 +199,7 @@ fun HomeScreen(
                     })
         (uiState.viewList) ->
             EventList(
-                events = uiState.eventList.allEvents,
+                events = uiState.upcomingEvents,
                 modifier =
                     Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(eventList) {
                       top.linkTo(searchAndFilter.bottom, margin = 8.dp)
@@ -208,7 +210,7 @@ fun HomeScreen(
                 }
         else ->
             EventMap(
-                uiState.eventList.allEvents,
+                uiState.upcomingEvents,
                 navigationActions,
                 Modifier.testTag("mapUpcoming").fillMaxWidth().constrainAs(eventMap) {
                   top.linkTo(tabs.bottom, margin = 8.dp)

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -188,31 +188,26 @@ fun HomeScreen(
                       start.linkTo(parent.start)
                       end.linkTo(parent.end)
                     })
+        (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
+            Text(
+                "You have no upcoming events",
+                modifier =
+                    Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
+                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                      start.linkTo(parent.start)
+                      end.linkTo(parent.end)
+                    })
         (uiState.viewList) ->
-            when {
-              (uiState.upcomingEventList.allEvents.isEmpty()) ->
-                  Text(
-                      "You have no upcoming events",
-                      modifier =
-                          Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
-                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-                          })
-              else ->
-                  EventList(
-                      events = uiState.upcomingEventList.allEvents,
-                      modifier =
-                          Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(
-                              eventList) {
-                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                                start.linkTo(parent.start)
-                                end.linkTo(parent.end)
-                              }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-            }
+            EventList(
+                events = uiState.upcomingEventList.allEvents,
+                modifier =
+                    Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(eventList) {
+                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                      start.linkTo(parent.start)
+                      end.linkTo(parent.end)
+                    }) { eventId ->
+                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
+                }
         else ->
             EventMap(
                 uiState.upcomingEventList.allEvents,

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -188,26 +188,31 @@ fun HomeScreen(
                       start.linkTo(parent.start)
                       end.linkTo(parent.end)
                     })
-        (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
-            Text(
-                "You have no upcoming events",
-                modifier =
-                    Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
-                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                      start.linkTo(parent.start)
-                      end.linkTo(parent.end)
-                    })
         (uiState.viewList) ->
-            EventList(
-                events = uiState.upcomingEventList.allEvents,
-                modifier =
-                    Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(eventList) {
-                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                      start.linkTo(parent.start)
-                      end.linkTo(parent.end)
-                    }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
+            when {
+              (uiState.upcomingEventList.allEvents.isEmpty()) ->
+                  Text(
+                      "You have no upcoming events",
+                      modifier =
+                          Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
+                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                          })
+              else ->
+                  EventList(
+                      events = uiState.upcomingEventList.allEvents,
+                      modifier =
+                          Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(
+                              eventList) {
+                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                                start.linkTo(parent.start)
+                                end.linkTo(parent.end)
+                              }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+            }
         else ->
             EventMap(
                 uiState.upcomingEventList.allEvents,

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -57,7 +57,10 @@ fun HomeScreen(
   // Ui States handled by viewModel
   val uiState by viewModel.uiState.collectAsState()
 
-  LaunchedEffect(Unit) { viewModel.getEvents() }
+  LaunchedEffect(Unit) { when{
+      (uiState.tab == Tab.BROWSE) -> viewModel.getEvents()
+      else -> viewModel.getUpcomingEvents()
+  }  }
 
   ConstraintLayout(modifier = Modifier.fillMaxSize().testTag("homeScreen")) {
     val (logo, tabs, searchAndFilter, filterPopUp, eventList, eventMap, bottomNav, viewToggle) =

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -188,7 +188,7 @@ fun HomeScreen(
                       start.linkTo(parent.start)
                       end.linkTo(parent.end)
                     })
-        (uiState.viewList && uiState.upcomingEvents.isEmpty()) ->
+        (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
             Text(
                 "You have no upcoming events",
                 modifier =
@@ -199,7 +199,7 @@ fun HomeScreen(
                     })
         (uiState.viewList) ->
             EventList(
-                events = uiState.upcomingEvents,
+                events = uiState.upcomingEventList.allEvents,
                 modifier =
                     Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(eventList) {
                       top.linkTo(searchAndFilter.bottom, margin = 8.dp)
@@ -210,7 +210,7 @@ fun HomeScreen(
                 }
         else ->
             EventMap(
-                uiState.upcomingEvents,
+                uiState.upcomingEventList.allEvents,
                 navigationActions,
                 Modifier.testTag("mapUpcoming").fillMaxWidth().constrainAs(eventMap) {
                   top.linkTo(tabs.bottom, margin = 8.dp)

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -186,7 +186,7 @@ fun HomeScreen(
                       start.linkTo(parent.start)
                       end.linkTo(parent.end)
                     })
-        (uiState.eventList.allEvents.isEmpty()) ->
+        (uiState.viewList && uiState.eventList.allEvents.isEmpty()) ->
             Text(
                 "You have no upcoming events",
                 modifier =

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.se.eventradar.model.Resource
-import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
 import com.github.se.eventradar.model.event.EventList
 import com.github.se.eventradar.model.repository.event.IEventRepository
@@ -59,7 +58,8 @@ constructor(
             Log.d(
                 "EventsOverviewViewModel",
                 "Error fetching user ID: ${userIdResource.throwable.message}")
-            _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
+            _uiState.value =
+                _uiState.value.copy(upcomingEventList = EventList(emptyList(), emptyList(), null))
           }
         }
       }
@@ -74,20 +74,27 @@ constructor(
         if (attendeeList.isNotEmpty()) {
           when (val events = eventRepository.getEventsByIds(attendeeList)) {
             is Resource.Success -> {
-              _uiState.value = _uiState.value.copy(upcomingEvents = events.data)
+              _uiState.value =
+                  _uiState.value.copy(
+                      upcomingEventList =
+                          EventList(
+                              events.data, events.data, _uiState.value.eventList.selectedEvent))
             }
             is Resource.Failure -> {
               Log.d("EventsOverviewViewModel", "Error getting events for $uid")
-              _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
+              _uiState.value =
+                  _uiState.value.copy(upcomingEventList = EventList(emptyList(), emptyList(), null))
             }
           }
         } else {
-          _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
+          _uiState.value =
+              _uiState.value.copy(upcomingEventList = EventList(emptyList(), emptyList(), null))
         }
       }
       is Resource.Failure -> {
         Log.d("EventsOverviewViewModel", "Error fetching user document")
-        _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
+        _uiState.value =
+            _uiState.value.copy(upcomingEventList = EventList(emptyList(), emptyList(), null))
       }
     }
   }
@@ -120,7 +127,7 @@ constructor(
 
 data class EventsOverviewUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
-    val upcomingEvents: List<Event> = emptyList(),
+    val upcomingEventList: EventList = EventList(emptyList(), emptyList(), null),
     val searchQuery: String = "",
     val isFilterDialogOpen: Boolean = false,
     var radiusInputFilter: Double = -1.0,

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/EventsOverviewViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.se.eventradar.model.Resource
+import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
 import com.github.se.eventradar.model.event.EventList
 import com.github.se.eventradar.model.repository.event.IEventRepository
@@ -58,8 +59,7 @@ constructor(
             Log.d(
                 "EventsOverviewViewModel",
                 "Error fetching user ID: ${userIdResource.throwable.message}")
-            _uiState.value =
-                _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+            _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
           }
         }
       }
@@ -74,26 +74,20 @@ constructor(
         if (attendeeList.isNotEmpty()) {
           when (val events = eventRepository.getEventsByIds(attendeeList)) {
             is Resource.Success -> {
-              _uiState.value =
-                  _uiState.value.copy(
-                      eventList =
-                          EventList(
-                              events.data, events.data, _uiState.value.eventList.selectedEvent))
+              _uiState.value = _uiState.value.copy(upcomingEvents = events.data)
             }
             is Resource.Failure -> {
               Log.d("EventsOverviewViewModel", "Error getting events for $uid")
-              _uiState.value =
-                  _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+              _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
             }
           }
         } else {
-          _uiState.value =
-              _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+          _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
         }
       }
       is Resource.Failure -> {
         Log.d("EventsOverviewViewModel", "Error fetching user document")
-        _uiState.value = _uiState.value.copy(eventList = EventList(emptyList(), emptyList(), null))
+        _uiState.value = _uiState.value.copy(upcomingEvents = emptyList())
       }
     }
   }
@@ -126,6 +120,7 @@ constructor(
 
 data class EventsOverviewUiState(
     val eventList: EventList = EventList(emptyList(), emptyList(), null),
+    val upcomingEvents: List<Event> = emptyList(),
     val searchQuery: String = "",
     val isFilterDialogOpen: Boolean = false,
     var radiusInputFilter: Double = -1.0,

--- a/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
@@ -134,8 +134,11 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("user1")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.upcomingEvents.size == 2)
-    assert(viewModel.uiState.value.upcomingEvents == listOf(event1, event2))
+    assert(viewModel.uiState.value.upcomingEventList.allEvents.size == 2)
+    assert(viewModel.uiState.value.upcomingEventList.allEvents == listOf(event1, event2))
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents.size == 2)
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents == listOf(event1, event2))
+    assertNull(viewModel.uiState.value.eventList.selectedEvent)
   }
 
   @Test
@@ -148,7 +151,9 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("user2")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents.isEmpty())
+    assertNull(viewModel.uiState.value.upcomingEventList.selectedEvent)
 
     verify { Log.d("EventsOverviewViewModel", "Error getting events for user2") }
     unmockkAll()
@@ -162,7 +167,9 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId(userId)
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents.isEmpty())
+    assertNull(viewModel.uiState.value.upcomingEventList.selectedEvent)
 
     verify { Log.d("EventsOverviewViewModel", "Error fetching user document") }
     unmockkAll()
@@ -176,7 +183,9 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("userWithEmptyList")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents.isEmpty())
+    assertNull(viewModel.uiState.value.upcomingEventList.selectedEvent)
   }
 
   @Test
@@ -187,7 +196,10 @@ class EventsOverviewViewModelTest {
 
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.allEvents.isEmpty())
+    assert(viewModel.uiState.value.upcomingEventList.filteredEvents.isEmpty())
+    assertNull(viewModel.uiState.value.upcomingEventList.selectedEvent)
+
     verify {
       Log.d("EventsOverviewViewModel", "Error fetching user ID: No user currently signed in")
     }

--- a/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
@@ -134,11 +134,8 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("user1")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.eventList.allEvents.size == 2)
-    assert(viewModel.uiState.value.eventList.allEvents == listOf(event1, event2))
-    assert(viewModel.uiState.value.eventList.filteredEvents.size == 2)
-    assert(viewModel.uiState.value.eventList.filteredEvents == listOf(event1, event2))
-    assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    assert(viewModel.uiState.value.upcomingEvents.size == 2)
+    assert(viewModel.uiState.value.upcomingEvents == listOf(event1, event2))
   }
 
   @Test
@@ -151,9 +148,7 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("user2")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
-    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
-    assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
 
     verify { Log.d("EventsOverviewViewModel", "Error getting events for user2") }
     unmockkAll()
@@ -167,9 +162,8 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId(userId)
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
-    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
-    assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
+
     verify { Log.d("EventsOverviewViewModel", "Error fetching user document") }
     unmockkAll()
   }
@@ -182,9 +176,7 @@ class EventsOverviewViewModelTest {
     (userRepository as MockUserRepository).updateCurrentUserId("userWithEmptyList")
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
-    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
-    assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
   }
 
   @Test
@@ -195,9 +187,7 @@ class EventsOverviewViewModelTest {
 
     viewModel.getUpcomingEvents()
 
-    assert(viewModel.uiState.value.eventList.allEvents.isEmpty())
-    assert(viewModel.uiState.value.eventList.filteredEvents.isEmpty())
-    assertNull(viewModel.uiState.value.eventList.selectedEvent)
+    assert(viewModel.uiState.value.upcomingEvents.isEmpty())
     verify {
       Log.d("EventsOverviewViewModel", "Error fetching user ID: No user currently signed in")
     }


### PR DESCRIPTION
### Key Changes:

- Bug Fix: Previously, navigating away from and then returning to the Upcoming tab incorrectly displayed all events instead of just the upcoming ones. This issue has been resolved.

- When you have no upcomings events, pressing on map icon now shows the map.

- Enhanced the EventsOverviewUiState by introducing a new upcoming events list to differentiate between all events and specifically upcoming ones. This update ensures clearer state management and optimizes UI updates specific to upcoming events, improving the responsiveness and accuracy of event displays.