### PR TITLE
Add profile picture to Messages list

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
@@ -19,13 +19,13 @@ import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onCompose
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.unmockkAll
-import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 class MessagesTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
@@ -63,7 +63,7 @@ class MessagesTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
               eventsAttendeeList = mutableListOf(),
               eventsHostList = mutableListOf(),
               friendsList = mutableListOf(),
-              profilePicUrl = "",
+              profilePicUrl = "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2Fplaceholder.png?alt=media&token=ba4b4efb-ff45-4617-b60f-3789e8fb75b6",
               qrCodeUrl = "",
               username = "Test$i"))
 

--- a/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
@@ -63,7 +63,8 @@ class MessagesTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
               eventsAttendeeList = mutableListOf(),
               eventsHostList = mutableListOf(),
               friendsList = mutableListOf(),
-              profilePicUrl = "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2Fplaceholder.png?alt=media&token=ba4b4efb-ff45-4617-b60f-3789e8fb75b6",
+              profilePicUrl =
+                  "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2Fplaceholder.png?alt=media&token=ba4b4efb-ff45-4617-b60f-3789e8fb75b6",
               qrCodeUrl = "",
               username = "Test$i"))
 

--- a/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
@@ -19,13 +19,13 @@ import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onCompose
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.unmockkAll
+import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 class MessagesTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {

--- a/app/src/main/java/com/github/se/eventradar/ui/messages/Messages.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/messages/Messages.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.github.se.eventradar.ExcludeFromJacocoGeneratedReport
 import com.github.se.eventradar.R
 import com.github.se.eventradar.model.User
@@ -225,10 +227,18 @@ fun MessagePreviewItem(
       verticalAlignment = Alignment.CenterVertically) {
         Image(
             painter =
-                painterResource(
-                    id = R.drawable.placeholder), // TODO: replace with actual profile pic
+                rememberAsyncImagePainter(
+                    ImageRequest.Builder(LocalContext.current)
+                        .data(data = recipient.profilePicUrl)
+                        .apply(
+                            block =
+                                fun ImageRequest.Builder.() {
+                                  crossfade(false)
+                                  placeholder(R.drawable.placeholder)
+                                })
+                        .build()),
             contentDescription = "Profile picture of ${recipient.firstName} ${recipient.lastName}",
-            contentScale = ContentScale.FillHeight,
+            contentScale = ContentScale.Crop,
             modifier =
                 Modifier.padding(start = 16.dp).clip(CircleShape).size(56.dp).testTag("profilePic"))
         Column(
@@ -338,14 +348,14 @@ fun PreviewMessagesScreen() {
             it,
             "10/10/2003",
             "test@test.com",
-            "John",
-            "Doe",
+            "Test",
+            it,
             "1234567890",
             "active",
             mutableListOf(),
             mutableListOf(),
             mutableListOf(),
-            "content://com.google.android.apps.docs.storage/document/acc%3D1%3Bdoc%3Dencoded%3D_UfMfUb7G-_gMA2naQlf9EvwC7BF37dTn3wqEbCsPCFqL25u15za15OI19GK4g%3D",
+            "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2FYJP3bYiaGFPqx64CT6kHOpwvXnv1?alt=media&token=5587f942-efc7-4cbf-920c-7f24a76d7ad1",
             "",
             "johndoe")
       })
@@ -372,7 +382,7 @@ fun PreviewEmptyMessagesList() {
             mutableListOf(),
             mutableListOf(),
             mutableListOf(),
-            "content://com.google.android.apps.docs.storage/document/acc%3D1%3Bdoc%3Dencoded%3D_UfMfUb7G-_gMA2naQlf9EvwC7BF37dTn3wqEbCsPCFqL25u15za15OI19GK4g%3D",
+            "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2FYJP3bYiaGFPqx64CT6kHOpwvXnv1?alt=media&token=5587f942-efc7-4cbf-920c-7f24a76d7ad1",
             "",
             "johndoe")
       },

--- a/app/src/main/java/com/github/se/eventradar/ui/messages/Messages.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/messages/Messages.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.rememberAsyncImagePainter
+import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.github.se.eventradar.ExcludeFromJacocoGeneratedReport
 import com.github.se.eventradar.R
@@ -225,18 +225,10 @@ fun MessagePreviewItem(
               .testTag("messagePreviewItem"),
       horizontalArrangement = Arrangement.Absolute.SpaceEvenly,
       verticalAlignment = Alignment.CenterVertically) {
-        Image(
-            painter =
-                rememberAsyncImagePainter(
-                    ImageRequest.Builder(LocalContext.current)
-                        .data(data = recipient.profilePicUrl)
-                        .apply(
-                            block =
-                                fun ImageRequest.Builder.() {
-                                  crossfade(false)
-                                  placeholder(R.drawable.placeholder)
-                                })
-                        .build()),
+        AsyncImage(
+            model =
+                ImageRequest.Builder(LocalContext.current).data(recipient.profilePicUrl).build(),
+            placeholder = painterResource(id = R.drawable.placeholder),
             contentDescription = "Profile picture of ${recipient.firstName} ${recipient.lastName}",
             contentScale = ContentScale.Crop,
             modifier =


### PR DESCRIPTION
## Objectives
- add the profile picture of each friend to the message screen to be in line with the Figma

## Key Changes
- retrieve the profile picture from the User object for each user in the messages list
- update preview screens and test to use Firebase Storage

## Demo
https://github.com/swent-sp-2024-event-radar/event-radar-app/assets/64320145/c05cd8e9-f6a9-4bb6-bec6-4423174e6cce

Closes #255 