### PR TITLE
Use scaffold layout instead of constraint layout

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/ViewEventDetailsUserFlow.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/ViewEventDetailsUserFlow.kt
@@ -130,9 +130,10 @@ class ViewEventDetailsUserFlow : TestCase() {
           assertIsDisplayed()
           assertTextContains("Social")
         }
-        dateTimeTitle { assertIsDisplayed() }
-        dateTimeStartContent { assertIsDisplayed() }
-        dateTimeEndContent { assertIsDisplayed() }
+        dateTitle { assertIsDisplayed() }
+        dateContent { assertIsDisplayed() }
+        timeTitle { assertIsDisplayed() }
+        timeContent { assertIsDisplayed() }
       }
     }
   }

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/ViewEventDetailsUserFlow.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/ViewEventDetailsUserFlow.kt
@@ -106,7 +106,7 @@ class ViewEventDetailsUserFlow : TestCase() {
         searchBarAndFilter { assertIsDisplayed() }
         searchBar { performTextInput("Test 1") }
 
-        filteredEventList { assertIsDisplayed() }
+        eventList { assertIsDisplayed() }
         eventCard { assertIsDisplayed() }
       }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/event/EventDetailsAttendingUITest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/event/EventDetailsAttendingUITest.kt
@@ -94,9 +94,10 @@ class EventDetailsAttendingUITest :
         assertIsDisplayed()
         assertTextContains("Community")
       }
-      dateTimeTitle { assertIsDisplayed() }
-      dateTimeStartContent { assertIsDisplayed() }
-      dateTimeEndContent { assertIsDisplayed() }
+      dateTitle { assertIsDisplayed() }
+      dateContent { assertIsDisplayed() }
+      timeTitle { assertIsDisplayed() }
+      timeContent { assertIsDisplayed() }
 
       attendance { assertIsDisplayed() }
     }

--- a/app/src/androidTest/java/com/github/se/eventradar/event/EventDetailsUITest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/event/EventDetailsUITest.kt
@@ -44,8 +44,8 @@ class EventDetailsUITest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCom
           EventUiState(
               eventName = "Debugging",
               eventPhoto = "path",
-              start = LocalDateTime.MIN,
-              end = LocalDateTime.MAX,
+              start = LocalDateTime.parse("2022-01-01T10:00:00"),
+              end = LocalDateTime.parse("2022-01-01T12:00:00"),
               location = Location(0.0, 0.0, "base address"),
               description = "Let's debug some code together because we all enjoy kotlin !",
               ticket = EventTicket("Luck", 0.0, 7, 0),
@@ -91,9 +91,10 @@ class EventDetailsUITest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCom
         assertIsDisplayed()
         assertTextContains("Community")
       }
-      dateTimeTitle { assertIsDisplayed() }
-      dateTimeStartContent { assertIsDisplayed() }
-      dateTimeEndContent { assertIsDisplayed() }
+      dateTitle { assertIsDisplayed() }
+      dateContent { assertIsDisplayed() }
+      timeTitle { assertIsDisplayed() }
+      timeContent { assertIsDisplayed() }
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/home/HomeTest.kt
@@ -1,10 +1,8 @@
 package com.github.se.eventradar.home
 
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.eventradar.model.Location
 import com.github.se.eventradar.model.event.Event
@@ -225,7 +223,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       verify { mockEventsOverviewViewModel.onFilterApply() }
 
       // 6. Check filtered events are displayed
-      filteredEventList { assertIsDisplayed() }
+      eventList { assertIsDisplayed() }
       eventCard { assertIsDisplayed() }
       verify { mockEventsOverviewViewModel.uiState }
       verify { mockEventsOverviewViewModel.filterEvents() }
@@ -244,7 +242,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       // Update the UI state to reflect the change
       sampleEventList.value = sampleEventList.value.copy(isSearchActive = true)
 
-      filteredEventList { assertIsDisplayed() }
+      eventList { assertIsDisplayed() }
       eventCard { assertIsDisplayed() }
 
       verify { mockEventsOverviewViewModel.onSearchQueryChanged("Event 0") }
@@ -292,7 +290,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       verify { mockEventsOverviewViewModel.uiState }
 
       // 3. Check filtered map is displayed
-      filteredMap { assertIsDisplayed() }
+      map { assertIsDisplayed() }
       verify { mockEventsOverviewViewModel.filterEvents() }
 
       // 4. Clear search
@@ -433,7 +431,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       // Update the UI state to reflect the change
       sampleEventList.value = sampleEventList.value.copy(isSearchActive = true)
 
-      filteredEventListUpcoming { assertIsDisplayed() }
+      eventListUpcoming { assertIsDisplayed() }
       eventCard { assertIsDisplayed() }
 
       verify { mockEventsOverviewViewModel.onSearchQueryChanged("Event 1") }
@@ -484,7 +482,7 @@ class HomeTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
       // Update the UI state to reflect the change
       sampleEventList.value = sampleEventList.value.copy(isSearchActive = true)
 
-      filteredMapUpcoming { assertIsDisplayed() }
+      mapUpcoming { assertIsDisplayed() }
 
       verify { mockEventsOverviewViewModel.onSearchQueryChanged("Event 1") }
       verify { mockEventsOverviewViewModel.onSearchActiveChanged(true) }

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/EventDetailsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/EventDetailsScreen.kt
@@ -22,10 +22,9 @@ public class EventDetailsScreen(semanticsProvider: SemanticsNodeInteractionsProv
   val distanceContent: KNode = onNode { hasTestTag("distanceContent") }
   val dateTitle: KNode = onNode { hasTestTag("dateTitle") }
   val dateContent: KNode = onNode { hasTestTag("dateContent") }
+  val timeTitle: KNode = onNode { hasTestTag("timeTitle") }
+  val timeContent: KNode = onNode { hasTestTag("timeContent") }
   val categoryTitle: KNode = onNode { hasTestTag("categoryTitle") }
   val categoryContent: KNode = onNode { hasTestTag("categoryContent") }
-  val dateTimeTitle: KNode = onNode { hasTestTag("timeTitle") }
-  val dateTimeStartContent: KNode = onNode { hasTestTag("timeStartContent") }
-  val dateTimeEndContent: KNode = onNode { hasTestTag("timeEndContent") }
   val attendance: KNode = onNode { hasTestTag("attendance") }
 }

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
@@ -15,20 +15,16 @@ class HomeScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val eventCard: KNode = onNode { hasTestTag("eventCard") }
   val bottomNav: KNode = child { hasTestTag("bottomNavMenu") }
   val viewToggleFab: KNode = child { hasTestTag("viewToggleFab") }
-  val map: KNode = child { hasTestTag("map") }
+  val map: KNode = child { hasTestTag("eventMap") }
   val eventList: KNode = child { hasTestTag("eventList") }
   val searchBarAndFilter: KNode = child { hasTestTag("searchBarAndFilter") }
   val filterButton: KNode = searchBarAndFilter.child { hasTestTag("filterButton") }
   val searchBar: KNode = searchBarAndFilter.child { hasTestTag("searchBar") }
   val filterPopUp: KNode = child { hasTestTag("filterPopUp") }
-  val filteredEventList: KNode = child { hasTestTag("filteredEventList") }
-  val filteredEventListUpcoming: KNode = child { hasTestTag("filteredEventListUpcoming") }
-  val filteredMap: KNode = child { hasTestTag("filteredMap") }
-  val filteredMapUpcoming: KNode = child { hasTestTag("filteredMapUpcoming") }
   val noUpcomingEventsText: KNode = child { hasTestTag("noUpcomingEventsText") }
   val pleaseLogInText: KNode = child { hasTestTag("pleaseLogInText") }
   val eventListUpcoming: KNode = child { hasTestTag("eventListUpcoming") }
-  val mapUpcoming: KNode = child { hasTestTag("mapUpcoming") }
+  val mapUpcoming: KNode = child { hasTestTag("eventMapUpcoming") }
 
   private val filterCard: KNode = filterPopUp.child { hasTestTag("filterCard") }
   private val filterCardColumn: KNode = filterCard.child { hasTestTag("filterCardColumn") }

--- a/app/src/main/java/com/github/se/eventradar/ui/component/EventUiComponents.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/component/EventUiComponents.kt
@@ -52,7 +52,7 @@ data class EventComponentsStyle(
 )
 
 fun formatDateTime(dateTime: LocalDateTime): String {
-  val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy - HH:mm")
+  val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
   return dateTime.format(formatter)
 }
 
@@ -115,23 +115,43 @@ fun EventCategory(modifier: Modifier, eventUiState: EventUiState, style: EventCo
 }
 
 @Composable
-fun EventDateTime(modifier: Modifier, eventUiState: EventUiState, style: EventComponentsStyle) {
+fun EventDate(modifier: Modifier, eventUiState: EventUiState, style: EventComponentsStyle) {
   Column(modifier = modifier) {
     Text(
-        text = stringResource(id = R.string.event_date_and_time),
+        text = stringResource(id = R.string.event_date),
         style = style.fieldTitleStyle,
-        color = style.titleColor,
+        color = style.fieldTitleColor,
+        modifier = Modifier.testTag("dateTitle"))
+
+    if (eventUiState.start.dayOfYear == eventUiState.end.dayOfYear) {
+      Text(
+          text = formatDateTime(eventUiState.start),
+          style = style.contentStyle,
+          color = style.contentColor,
+          modifier = Modifier.testTag("dateContent"))
+      return
+    } else {
+      Text(
+          text = "${formatDateTime(eventUiState.start)} - ${formatDateTime(eventUiState.end)}",
+          style = style.contentStyle,
+          color = style.contentColor,
+          modifier = Modifier.testTag("dateContent"))
+    }
+  }
+}
+
+@Composable
+fun EventTime(modifier: Modifier, eventUiState: EventUiState, style: EventComponentsStyle) {
+  Column(modifier = modifier) {
+    Text(
+        text = stringResource(id = R.string.event_time),
+        style = style.fieldTitleStyle,
+        color = style.fieldTitleColor,
         modifier = Modifier.testTag("timeTitle"))
     Text(
-        text =
-            "${stringResource(id = R.string.event_dt_start)}: ${formatDateTime(eventUiState.start)}",
+        text = "${eventUiState.start.toLocalTime()} - ${eventUiState.end.toLocalTime()}",
         style = style.contentStyle,
         color = style.contentColor,
-        modifier = Modifier.testTag("timeStartContent"))
-    Text(
-        text = "${stringResource(id = R.string.event_dt_end)}: ${formatDateTime(eventUiState.end)}",
-        style = style.contentStyle,
-        color = style.contentColor,
-        modifier = Modifier.testTag("timeEndContent"))
+        modifier = Modifier.testTag("timeContent"))
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/component/EventUiComponents.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/component/EventUiComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.github.se.eventradar.R
 import com.github.se.eventradar.viewmodel.EventUiState
@@ -28,14 +29,13 @@ data class EventComponentsStyle(
             fontSize = 32.sp,
             fontFamily = FontFamily(Font(R.font.roboto)),
             fontWeight = FontWeight.Bold,
-            lineHeight = 20.sp,
+            textAlign = TextAlign.Center,
         ),
     val subTitleStyle: TextStyle =
         TextStyle(
             fontSize = 22.sp,
             fontFamily = FontFamily(Font(R.font.roboto)),
             fontWeight = FontWeight.Medium,
-            lineHeight = 20.sp,
         ),
     val fieldTitleStyle: TextStyle =
         TextStyle(

--- a/app/src/main/java/com/github/se/eventradar/ui/component/ReusableComponents.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/component/ReusableComponents.kt
@@ -315,20 +315,20 @@ fun FilterPopUp(
 fun CategorySelection(uiState: EventsOverviewUiState, modifier: Modifier) {
   LazyColumn(modifier = modifier) {
     items(EventCategory.entries.subList(0, EventCategory.entries.size / 2 + 1)) { category ->
-      CategoryRow(category, uiState)
+      CategoryDisplayColumn(category, uiState)
     }
   }
   LazyColumn(modifier = modifier) {
     items(
         EventCategory.entries.subList(
             EventCategory.entries.size / 2 + 1, EventCategory.entries.size)) { category ->
-          CategoryRow(category, uiState)
+          CategoryDisplayColumn(category, uiState)
         }
   }
 }
 
 @Composable
-fun CategoryRow(
+fun CategoryDisplayColumn(
     category: EventCategory,
     uiState: EventsOverviewUiState,
 ) {
@@ -397,18 +397,12 @@ fun ProfilePic(
 fun AppScaffold(
     modifier: Modifier = Modifier,
     topBar: @Composable () -> Unit = {
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp).testTag("logo"),
-          verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(id = R.drawable.event_logo),
-                contentDescription = "Event Radar Logo",
-                modifier = Modifier.size(width = 186.dp, height = 50.dp))
-          }
+      Logo(modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp).testTag("logo"))
     },
     floatingActionButton: @Composable () -> Unit,
     navigationActions: NavigationActions,
-    content: @Composable (PaddingValues) -> Unit
+    selectedItem: String = Route.HOME,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
   Scaffold(
       modifier = modifier,
@@ -417,7 +411,7 @@ fun AppScaffold(
         BottomNavigationMenu(
             onTabSelected = navigationActions::navigateTo,
             tabList = TOP_LEVEL_DESTINATIONS,
-            selectedItem = getTopLevelDestination(Route.HOME),
+            selectedItem = getTopLevelDestination(selectedItem),
             modifier = Modifier.testTag("bottomNavMenu"))
       },
       floatingActionButton = floatingActionButton,

--- a/app/src/main/java/com/github/se/eventradar/ui/component/ReusableComponents.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/component/ReusableComponents.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -15,6 +16,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -33,6 +36,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -66,6 +70,11 @@ import coil.request.ImageRequest
 import com.github.se.eventradar.R
 import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.event.EventCategory
+import com.github.se.eventradar.ui.BottomNavigationMenu
+import com.github.se.eventradar.ui.navigation.NavigationActions
+import com.github.se.eventradar.ui.navigation.Route
+import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.github.se.eventradar.ui.navigation.getTopLevelDestination
 import com.github.se.eventradar.viewmodel.EventsOverviewUiState
 
 fun getIconFromViewListBool(viewList: Boolean): ImageVector {
@@ -214,70 +223,70 @@ fun FilterPopUp(
         modifier = Modifier.padding(12.dp).testTag("filterCard"),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
-      Column(modifier = Modifier.fillMaxSize().padding(12.dp).testTag("filterCardColumn")) {
+      Column(modifier = Modifier.padding(12.dp).testTag("filterCardColumn")) {
         // Text input for radius
-        Row(modifier = Modifier.fillMaxWidth().testTag("filterCardColumnRow")) {
-          Box(modifier = Modifier.weight(1f).testTag("filterCardColumnRowRadius")) {
-            Text(
-                text = stringResource(id = R.string.radius_label),
-                style = TextStyle(fontSize = 16.sp),
-                modifier = Modifier.testTag("radiusLabel"))
-          }
-          Box(modifier = Modifier.weight(1f).testTag("radiusInputBox")) {
-            BasicTextField(
-                value = uiState.radiusQuery,
-                onValueChange = { onRadiusQueryChanged(it) },
-                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .border(
-                            width = 1.dp,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            shape = RoundedCornerShape(10))
-                        .testTag("radiusInput"),
-                textStyle = TextStyle.Default.copy(fontSize = 16.sp),
-                singleLine = true)
-          }
-          Box(modifier = Modifier.weight(1f).testTag("filterCardColumnRowKm")) {
-            Text(
-                text = stringResource(id = R.string.radius_km_label),
-                style = TextStyle(fontSize = 16.sp),
-                modifier = Modifier.testTag("kmLabel"))
-          }
-        }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        // Slider for free selection
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start,
-            modifier = Modifier.testTag("freeSwitchRow")) {
-              Text(
-                  text = stringResource(id = R.string.free_events_label),
-                  style =
-                      TextStyle(
-                          fontSize = 16.sp,
-                      ),
-                  modifier = Modifier.testTag("freeSwitchLabel"))
-              Switch(
-                  checked = uiState.isFreeSwitchOn,
-                  onCheckedChange = { onFreeSwitchChanged() },
-                  modifier = Modifier.testTag("freeSwitch"))
+            modifier = Modifier.wrapContentWidth().testTag("filterCardColumnRow"),
+            verticalAlignment = Alignment.CenterVertically) {
+              Row(modifier = Modifier.weight(1f)) {
+                Box(modifier = Modifier.testTag("filterCardColumnRowRadius")) {
+                  Text(
+                      text = stringResource(id = R.string.radius_label),
+                      style = TextStyle(fontSize = 16.sp),
+                      modifier = Modifier.testTag("radiusLabel"))
+                }
+                Box(modifier = Modifier.testTag("radiusInputBox")) {
+                  BasicTextField(
+                      value = uiState.radiusQuery,
+                      onValueChange = { onRadiusQueryChanged(it) },
+                      keyboardOptions =
+                          KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                      modifier =
+                          Modifier.widthIn(max = 36.dp)
+                              .border(
+                                  width = 1.dp,
+                                  color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                  shape = RoundedCornerShape(10))
+                              .testTag("radiusInput"),
+                      textStyle = TextStyle.Default.copy(fontSize = 16.sp),
+                      singleLine = true)
+                }
+                Box(modifier = Modifier.testTag("filterCardColumnRowKm")) {
+                  Text(
+                      text = stringResource(id = R.string.radius_km_label),
+                      style = TextStyle(fontSize = 16.sp),
+                      modifier = Modifier.testTag("kmLabel"))
+                }
+              }
+              // Slider for free selection
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.weight(1.5f).testTag("freeSwitchRow")) {
+                    Text(
+                        text = stringResource(id = R.string.free_events_label),
+                        style =
+                            TextStyle(
+                                fontSize = 16.sp,
+                            ),
+                        modifier = Modifier.testTag("freeSwitchLabel"))
+                    Switch(
+                        checked = uiState.isFreeSwitchOn,
+                        onCheckedChange = { onFreeSwitchChanged() },
+                        modifier = Modifier.widthIn(32.dp).testTag("freeSwitch"))
+                  }
             }
 
         // Buttons for category selection
         Text(
             text = stringResource(id = R.string.category_label),
-            modifier = Modifier.weight(1f).testTag("categoryLabel"),
+            modifier = Modifier.testTag("categoryLabel"),
             style =
                 TextStyle(
                     fontSize = 16.sp,
                 ))
 
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start,
+            horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.testTag("categoryRow"),
         ) {
           CategorySelection(
@@ -290,7 +299,7 @@ fun FilterPopUp(
 
         // Button to apply filter
         Row(
-            modifier = Modifier.fillMaxWidth().testTag("filterApplyRow"),
+            modifier = Modifier.testTag("filterApplyRow"),
             horizontalArrangement = Arrangement.Center) {
               Button(
                   onClick = { onFilterApply() }, modifier = Modifier.testTag("filterApplyButton")) {
@@ -305,36 +314,49 @@ fun FilterPopUp(
 @Composable
 fun CategorySelection(uiState: EventsOverviewUiState, modifier: Modifier) {
   LazyColumn(modifier = modifier) {
-    items(EventCategory.entries) { category ->
-      var isChecked by remember { mutableStateOf(uiState.categoriesCheckedList.contains(category)) }
-      Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.Start,
-          modifier =
-              Modifier.padding(vertical = 0.dp)
-                  .testTag("categoryOptionRow-${category.displayName}")) {
-            Checkbox(
-                checked = isChecked,
-                onCheckedChange = {
-                  isChecked = it
-                  if (isChecked) {
-                    uiState.categoriesCheckedList.add(category)
-                  } else {
-                    uiState.categoriesCheckedList.remove(category)
-                  }
-                },
-                modifier =
-                    Modifier.scale(0.6f).size(10.dp).padding(start = 10.dp).testTag("checkbox"))
-            Text(
-                text = category.displayName,
-                style =
-                    TextStyle(
-                        fontSize = 16.sp,
-                    ),
-                modifier = Modifier.padding(start = 16.dp).testTag("checkboxText"))
-          }
+    items(EventCategory.entries.subList(0, EventCategory.entries.size / 2 + 1)) { category ->
+      CategoryRow(category, uiState)
     }
   }
+  LazyColumn(modifier = modifier) {
+    items(
+        EventCategory.entries.subList(
+            EventCategory.entries.size / 2 + 1, EventCategory.entries.size)) { category ->
+          CategoryRow(category, uiState)
+        }
+  }
+}
+
+@Composable
+fun CategoryRow(
+    category: EventCategory,
+    uiState: EventsOverviewUiState,
+) {
+  var isChecked by remember { mutableStateOf(uiState.categoriesCheckedList.contains(category)) }
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.Start,
+      modifier =
+          Modifier.padding(vertical = 0.dp).testTag("categoryOptionRow-${category.displayName}")) {
+        Checkbox(
+            checked = isChecked,
+            onCheckedChange = {
+              isChecked = it
+              if (isChecked) {
+                uiState.categoriesCheckedList.add(category)
+              } else {
+                uiState.categoriesCheckedList.remove(category)
+              }
+            },
+            modifier = Modifier.scale(0.6f).size(10.dp).padding(start = 10.dp).testTag("checkbox"))
+        Text(
+            text = category.displayName,
+            style =
+                TextStyle(
+                    fontSize = 16.sp,
+                ),
+            modifier = Modifier.padding(start = 16.dp).testTag("checkboxText"))
+      }
 }
 
 @Composable
@@ -369,4 +391,37 @@ fun ProfilePic(
       contentDescription = "Profile picture of $firstName $lastName",
       contentScale = ContentScale.Crop,
       modifier = modifier.padding(start = 16.dp).clip(CircleShape).size(56.dp))
+}
+
+@Composable
+fun AppScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp).testTag("logo"),
+          verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                painter = painterResource(id = R.drawable.event_logo),
+                contentDescription = "Event Radar Logo",
+                modifier = Modifier.size(width = 186.dp, height = 50.dp))
+          }
+    },
+    floatingActionButton: @Composable () -> Unit,
+    navigationActions: NavigationActions,
+    content: @Composable (PaddingValues) -> Unit
+) {
+  Scaffold(
+      modifier = modifier,
+      topBar = topBar,
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelected = navigationActions::navigateTo,
+            tabList = TOP_LEVEL_DESTINATIONS,
+            selectedItem = getTopLevelDestination(Route.HOME),
+            modifier = Modifier.testTag("bottomNavMenu"))
+      },
+      floatingActionButton = floatingActionButton,
+  ) {
+    content(it)
+  }
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/event/EventDetails.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,7 +33,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.eventradar.R
-import com.github.se.eventradar.ui.BottomNavigationMenu
+import com.github.se.eventradar.ui.component.AppScaffold
 import com.github.se.eventradar.ui.component.EventCategory
 import com.github.se.eventradar.ui.component.EventComponentsStyle
 import com.github.se.eventradar.ui.component.EventDate
@@ -45,7 +44,6 @@ import com.github.se.eventradar.ui.component.EventTitle
 import com.github.se.eventradar.ui.component.GoBackButton
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
-import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.github.se.eventradar.viewmodel.EventDetailsViewModel
 
 // Temporary sizes. Needs to be responsive...
@@ -66,17 +64,10 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
           MaterialTheme.colorScheme.onSurface,
       )
 
-  Scaffold(
+  AppScaffold(
       modifier = Modifier.testTag("eventDetailsScreen"),
       topBar = {
         GoBackButton(modifier = Modifier.wrapContentSize()) { navigationActions.goBack() }
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelected = { tab -> navigationActions.navigateTo(tab) },
-            tabList = TOP_LEVEL_DESTINATIONS,
-            selectedItem = TOP_LEVEL_DESTINATIONS[2],
-            modifier = Modifier.testTag("bottomNavMenu"))
       },
       floatingActionButton = {
         // view ticket button
@@ -97,7 +88,8 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
             )
           }
         }
-      }) {
+      },
+      navigationActions = navigationActions) {
         Column(
             modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(it)) {
               // TODO uncomment when image are implemented
@@ -117,11 +109,11 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
               Spacer(modifier = Modifier.height(8.dp))
 
               Column(
-                  modifier = Modifier.padding(horizontal = 8.dp),
+                  modifier = Modifier.padding(horizontal = 16.dp),
                   horizontalAlignment = Alignment.CenterHorizontally) {
                     EventDescription(modifier = Modifier, eventUiState, componentStyle)
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                       EventDistance(modifier = Modifier.weight(2f), eventUiState, componentStyle)

--- a/app/src/main/java/com/github/se/eventradar/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/event/EventDetails.kt
@@ -1,12 +1,16 @@
 package com.github.se.eventradar.ui.event
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
@@ -26,16 +31,16 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.github.se.eventradar.R
 import com.github.se.eventradar.ui.BottomNavigationMenu
 import com.github.se.eventradar.ui.component.EventCategory
 import com.github.se.eventradar.ui.component.EventComponentsStyle
-import com.github.se.eventradar.ui.component.EventDateTime
+import com.github.se.eventradar.ui.component.EventDate
 import com.github.se.eventradar.ui.component.EventDescription
 import com.github.se.eventradar.ui.component.EventDistance
+import com.github.se.eventradar.ui.component.EventTime
 import com.github.se.eventradar.ui.component.EventTitle
 import com.github.se.eventradar.ui.component.GoBackButton
 import com.github.se.eventradar.ui.navigation.NavigationActions
@@ -44,7 +49,6 @@ import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.github.se.eventradar.viewmodel.EventDetailsViewModel
 
 // Temporary sizes. Needs to be responsive...
-private val widthPadding = 34.dp
 private val imageHeight = 191.dp
 
 @Composable
@@ -64,7 +68,9 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
 
   Scaffold(
       modifier = Modifier.testTag("eventDetailsScreen"),
-      topBar = {},
+      topBar = {
+        GoBackButton(modifier = Modifier.wrapContentSize()) { navigationActions.goBack() }
+      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelected = { tab -> navigationActions.navigateTo(tab) },
@@ -80,7 +86,7 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
                 navigationActions.navController.navigate(
                     "${Route.EVENT_DETAILS_TICKETS}/${viewModel.eventId}")
               },
-              modifier = Modifier.padding(bottom = 16.dp, end = 16.dp).testTag("ticketButton"),
+              modifier = Modifier.testTag("ticketButton"),
               containerColor = MaterialTheme.colorScheme.primaryContainer,
           ) {
             Icon(
@@ -91,103 +97,62 @@ fun EventDetails(viewModel: EventDetailsViewModel, navigationActions: Navigation
             )
           }
         }
-      }) { innerPadding ->
-        ConstraintLayout(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-          val (image, backButton, title, description, distance, category, dateAndTime, joined) =
-              createRefs()
+      }) {
+        Column(
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(it)) {
+              // TODO uncomment when image are implemented
+              // val imagePainter: Painter = rememberAsyncImagePainter(eventUiState.eventPhoto)
+              val imagePainter: Painter = rememberAsyncImagePainter(R.drawable.placeholderbig)
+              Image(
+                  painter = imagePainter,
+                  contentDescription = "Event banner image",
+                  modifier = Modifier.fillMaxWidth().height(imageHeight).testTag("eventImage"),
+                  contentScale = ContentScale.FillWidth)
 
-          // TODO uncomment when image are implemented
-          // val imagePainter: Painter = rememberImagePainter(eventUiState.eventPhoto)
-          val imagePainter: Painter = rememberImagePainter(R.drawable.placeholderbig)
-          Image(
-              painter = imagePainter,
-              contentDescription = "Event banner image",
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .height(imageHeight)
-                      .constrainAs(image) {
-                        top.linkTo(parent.top, margin = 0.dp)
-                        start.linkTo(parent.start, margin = 0.dp)
-                      }
-                      .testTag("eventImage"),
-              contentScale = ContentScale.FillWidth)
+              EventTitle(
+                  modifier = Modifier.align(Alignment.CenterHorizontally),
+                  eventUiState = eventUiState,
+                  style = componentStyle)
 
-          // Go back button
-          GoBackButton(
-              modifier =
-                  Modifier.wrapContentSize().constrainAs(backButton) {
-                    top.linkTo(image.bottom, margin = 8.dp)
-                    start.linkTo(image.start, margin = 4.dp)
-                  }) {
-                navigationActions.goBack()
-              }
+              Spacer(modifier = Modifier.height(8.dp))
 
-          EventTitle(
-              modifier =
-                  Modifier.constrainAs(title) {
-                    top.linkTo(image.bottom, margin = 32.dp)
-                    start.linkTo(image.start)
-                    end.linkTo(image.end)
-                  },
-              eventUiState = eventUiState,
-              style = componentStyle)
+              Column(
+                  modifier = Modifier.padding(horizontal = 8.dp),
+                  horizontalAlignment = Alignment.CenterHorizontally) {
+                    EventDescription(modifier = Modifier, eventUiState, componentStyle)
 
-          EventDescription(
-              modifier =
-                  Modifier
-                      // .padding(start = widthPadding, end = widthPadding)
-                      .constrainAs(description) {
-                        top.linkTo(title.bottom, margin = 32.dp)
-                        start.linkTo(parent.start, margin = widthPadding)
-                      },
-              eventUiState,
-              componentStyle)
+                    Spacer(modifier = Modifier.height(8.dp))
 
-          EventDistance(
-              modifier =
-                  Modifier.constrainAs(distance) {
-                    top.linkTo(description.bottom, margin = 32.dp)
-                    start.linkTo(parent.start, margin = widthPadding)
-                  },
-              eventUiState,
-              componentStyle)
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                      EventDistance(modifier = Modifier.weight(2f), eventUiState, componentStyle)
 
-          EventDateTime(
-              modifier =
-                  Modifier.constrainAs(dateAndTime) {
-                    top.linkTo(distance.bottom, margin = 32.dp)
-                    start.linkTo(parent.start, margin = widthPadding)
-                  },
-              eventUiState,
-              componentStyle)
+                      EventDate(modifier = Modifier.weight(1f), eventUiState, componentStyle)
+                    }
 
-          EventCategory(
-              modifier =
-                  Modifier.constrainAs(category) {
-                    top.linkTo(dateAndTime.bottom, margin = 32.dp)
-                    start.linkTo(parent.start, margin = widthPadding)
-                  },
-              eventUiState,
-              componentStyle)
+                    Spacer(modifier = Modifier.height(8.dp))
 
-          if (isUserAttending) {
-            Text(
-                text = stringResource(id = R.string.event_attendance_message),
-                modifier =
-                    Modifier.constrainAs(joined) {
-                          top.linkTo(category.bottom, margin = 32.dp)
-                          start.linkTo(parent.start, margin = widthPadding)
-                          end.linkTo(parent.end, margin = widthPadding)
-                        }
-                        .testTag("attendance"),
-                style =
-                    TextStyle(
-                        fontSize = 18.sp,
-                        fontFamily = FontFamily(Font(R.font.roboto)),
-                        fontWeight = FontWeight.Bold,
-                    ),
-                color = MaterialTheme.colorScheme.primary)
-          }
-        }
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                      EventCategory(modifier = Modifier.weight(2f), eventUiState, componentStyle)
+
+                      EventTime(modifier = Modifier.weight(1f), eventUiState, componentStyle)
+                    }
+
+                    if (isUserAttending) {
+                      Spacer(modifier = Modifier.height(16.dp))
+                      Text(
+                          text = stringResource(id = R.string.event_attendance_message),
+                          modifier = Modifier.testTag("attendance"),
+                          style =
+                              TextStyle(
+                                  fontSize = 18.sp,
+                                  fontFamily = FontFamily(Font(R.font.roboto)),
+                                  fontWeight = FontWeight.Bold,
+                              ),
+                          color = MaterialTheme.colorScheme.primary)
+                    }
+
+                    // TODO: Add a cancel registration button
+                  }
+            }
       }
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/event/EventSelectTicket.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/event/EventSelectTicket.kt
@@ -1,10 +1,11 @@
 package com.github.se.eventradar.ui.event
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -35,7 +36,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.se.eventradar.R
 import com.github.se.eventradar.ui.BottomNavigationMenu
@@ -92,7 +92,9 @@ fun SelectTicket(viewModel: EventDetailsViewModel, navigationActions: Navigation
 
   Scaffold(
       modifier = Modifier.testTag("joinEventScreen"),
-      topBar = {},
+      topBar = {
+        GoBackButton(modifier = Modifier.wrapContentSize()) { navigationActions.goBack() }
+      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelected = { tab -> navigationActions.navigateTo(tab) },
@@ -104,7 +106,7 @@ fun SelectTicket(viewModel: EventDetailsViewModel, navigationActions: Navigation
         // buy ticket button
         FloatingActionButton(
             onClick = { viewModel.buyTicketForEvent() },
-            modifier = Modifier.padding(bottom = 16.dp, end = 16.dp).testTag("buyButton"),
+            modifier = Modifier.testTag("buyButton"),
             containerColor = MaterialTheme.colorScheme.primaryContainer,
         ) {
           val icon = if (viewModel.isTicketFree()) R.drawable.check else R.drawable.credit_card
@@ -115,50 +117,28 @@ fun SelectTicket(viewModel: EventDetailsViewModel, navigationActions: Navigation
               tint = MaterialTheme.colorScheme.onPrimaryContainer,
           )
         }
-      }) { innerPadding ->
-        ConstraintLayout(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-          val (backButton, title, ticketTitle, ticketCard) = createRefs()
-
-          GoBackButton(
-              modifier =
-                  Modifier.wrapContentSize().constrainAs(backButton) {
-                    top.linkTo(parent.top, margin = 12.dp)
-                    start.linkTo(parent.start)
-                  }) {
-                navigationActions.goBack()
-              }
-
+      }) {
+        Column(modifier = Modifier.fillMaxWidth().padding(it).padding(horizontal = 8.dp)) {
           EventTitle(
-              modifier =
-                  Modifier.constrainAs(title) {
-                    top.linkTo(backButton.bottom, margin = 42.dp)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                  },
+              modifier = Modifier.align(Alignment.CenterHorizontally),
               eventUiState = eventUiState,
               style = componentStyle)
 
+          Spacer(modifier = Modifier.height(24.dp))
+
           Text(
               text = stringResource(id = R.string.tickets_title),
-              modifier =
-                  Modifier.constrainAs(ticketTitle) {
-                        top.linkTo(title.bottom, margin = 32.dp)
-                        start.linkTo(parent.start, margin = 32.dp)
-                      }
-                      .testTag("ticketsTitle"),
+              modifier = Modifier.testTag("ticketsTitle"),
               style = componentStyle.subTitleStyle)
+
+          Spacer(modifier = Modifier.height(8.dp))
 
           Card(
               modifier =
-                  Modifier.padding(horizontal = 32.dp, vertical = 8.dp)
+                  Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                       .height(IntrinsicSize.Min)
                       .fillMaxWidth()
-                      .testTag("ticketCard")
-                      .constrainAs(ticketCard) {
-                        top.linkTo(ticketTitle.bottom, margin = 32.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      },
+                      .testTag("ticketCard"),
               colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
               elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
               onClick = {

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -56,6 +57,7 @@ fun HomeScreen(
 ) {
   // Ui States handled by viewModel
   val uiState by viewModel.uiState.collectAsState()
+
   LaunchedEffect(key1 = uiState.isSearchActive, key2 = uiState.isFilterActive) {
     if (uiState.isSearchActive || uiState.isFilterActive) {
       viewModel.filterEvents()
@@ -69,247 +71,247 @@ fun HomeScreen(
     }
   }
 
-  ConstraintLayout(modifier = Modifier.fillMaxSize().testTag("homeScreen")) {
-    val (logo, tabs, searchAndFilter, filterPopUp, eventList, eventMap, bottomNav, viewToggle) =
-        createRefs()
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .constrainAs(logo) {
-                  top.linkTo(parent.top, margin = 32.dp)
-                  start.linkTo(parent.start, margin = 16.dp)
+  Scaffold(
+      modifier = Modifier.testTag("homeScreen"),
+      topBar = {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp).testTag("logo"),
+            verticalAlignment = Alignment.CenterVertically) {
+              Image(
+                  painter = painterResource(id = R.drawable.event_logo),
+                  contentDescription = "Event Radar Logo",
+                  modifier = Modifier.size(width = 186.dp, height = 50.dp))
+            }
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelected = navigationActions::navigateTo,
+            tabList = TOP_LEVEL_DESTINATIONS,
+            selectedItem = getTopLevelDestination(Route.HOME),
+            modifier = Modifier.testTag("bottomNavMenu"))
+      },
+      floatingActionButton = {
+        ViewToggleFab(
+            modifier = Modifier.padding(16.dp).testTag("viewToggleFab"),
+            onClick = { viewModel.onViewListStatusChanged() },
+            iconVector = getIconFromViewListBool(uiState.viewList))
+      }) {
+        ConstraintLayout(modifier = Modifier.fillMaxSize().padding(it).testTag("homeScreen")) {
+          val (tabs, searchAndFilter, filterPopUp, eventList, eventMap) = createRefs()
+          TabRow(
+              selectedTabIndex = getTabIndexFromTabEnum(uiState.tab),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(top = 8.dp)
+                      .constrainAs(tabs) {
+                        top.linkTo(parent.top, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }
+                      .testTag("tabs"),
+              contentColor = MaterialTheme.colorScheme.primary) {
+                Tab(
+                    selected = getTabIndexFromTabEnum(uiState.tab) == 0,
+                    onClick = {
+                      viewModel.onTabChanged(Tab.BROWSE)
+                      viewModel.getEvents()
+                    },
+                    modifier = Modifier.testTag("browseTab"),
+                ) {
+                  Text(
+                      text = "Browse",
+                      style =
+                          TextStyle(
+                              fontSize = 19.sp,
+                              lineHeight = 17.sp,
+                              fontFamily = FontFamily(Font(R.font.roboto)),
+                              fontWeight = FontWeight(500),
+                              color = MaterialTheme.colorScheme.onPrimaryContainer,
+                              textAlign = TextAlign.Center,
+                              letterSpacing = 0.25.sp,
+                          ),
+                      modifier = Modifier.padding(bottom = 8.dp))
                 }
-                .testTag("logo"),
-        verticalAlignment = Alignment.CenterVertically) {
-          Image(
-              painter = painterResource(id = R.drawable.event_logo),
-              contentDescription = "Event Radar Logo",
-              modifier = Modifier.size(width = 186.dp, height = 50.dp))
-        }
-    TabRow(
-        selectedTabIndex = getTabIndexFromTabEnum(uiState.tab),
-        modifier =
-            Modifier.fillMaxWidth()
-                .padding(top = 8.dp)
-                .constrainAs(tabs) {
-                  top.linkTo(logo.bottom, margin = 16.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }
-                .testTag("tabs"),
-        contentColor = MaterialTheme.colorScheme.primary) {
-          Tab(
-              selected = getTabIndexFromTabEnum(uiState.tab) == 0,
-              onClick = {
-                viewModel.onTabChanged(Tab.BROWSE)
-                viewModel.getEvents()
-              },
-              modifier = Modifier.testTag("browseTab"),
-          ) {
-            Text(
-                text = "Browse",
-                style =
-                    TextStyle(
-                        fontSize = 19.sp,
-                        lineHeight = 17.sp,
-                        fontFamily = FontFamily(Font(R.font.roboto)),
-                        fontWeight = FontWeight(500),
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        textAlign = TextAlign.Center,
-                        letterSpacing = 0.25.sp,
-                    ),
-                modifier = Modifier.padding(bottom = 8.dp))
-          }
-          Tab(
-              selected = getTabIndexFromTabEnum(uiState.tab) == 1,
-              onClick = {
-                viewModel.onTabChanged(Tab.UPCOMING)
-                viewModel.getUpcomingEvents()
-              },
-              modifier = Modifier.testTag("upcomingTab")) {
-                Text(
-                    text = "Upcoming",
-                    style =
-                        TextStyle(
-                            fontSize = 19.sp,
-                            lineHeight = 17.sp,
-                            fontFamily = FontFamily(Font(R.font.roboto)),
-                            fontWeight = FontWeight(500),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            textAlign = TextAlign.Center,
-                            letterSpacing = 0.25.sp,
-                        ),
-                    modifier = Modifier.padding(bottom = 8.dp))
+                Tab(
+                    selected = getTabIndexFromTabEnum(uiState.tab) == 1,
+                    onClick = {
+                      viewModel.onTabChanged(Tab.UPCOMING)
+                      viewModel.getUpcomingEvents()
+                    },
+                    modifier = Modifier.testTag("upcomingTab")) {
+                      Text(
+                          text = "Upcoming",
+                          style =
+                              TextStyle(
+                                  fontSize = 19.sp,
+                                  lineHeight = 17.sp,
+                                  fontFamily = FontFamily(Font(R.font.roboto)),
+                                  fontWeight = FontWeight(500),
+                                  color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                  textAlign = TextAlign.Center,
+                                  letterSpacing = 0.25.sp,
+                              ),
+                          modifier = Modifier.padding(bottom = 8.dp))
+                    }
               }
-        }
 
-    SearchBarAndFilter(
-        onSearchQueryChanged = { viewModel.onSearchQueryChanged(it) },
-        searchQuery = uiState.searchQuery,
-        onSearchActiveChanged = { viewModel.onSearchActiveChanged(it) },
-        onFilterDialogOpen = { viewModel.onFilterDialogOpen() },
-        modifier =
-            Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                .testTag("searchBarAndFilter")
-                .constrainAs(searchAndFilter) {
-                  top.linkTo(tabs.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                },
-        placeholderStringResource = R.string.home_search_placeholder)
+          SearchBarAndFilter(
+              onSearchQueryChanged = { viewModel.onSearchQueryChanged(it) },
+              searchQuery = uiState.searchQuery,
+              onSearchActiveChanged = { viewModel.onSearchActiveChanged(it) },
+              onFilterDialogOpen = { viewModel.onFilterDialogOpen() },
+              modifier =
+                  Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                      .testTag("searchBarAndFilter")
+                      .constrainAs(searchAndFilter) {
+                        top.linkTo(tabs.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      },
+              placeholderStringResource = R.string.home_search_placeholder)
 
-    if (uiState.tab == Tab.BROWSE) {
-      when {
-        // In list view + search or filter is active
-        (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
-            EventList(
-                uiState.eventList.filteredEvents,
-                Modifier.testTag("filteredEventList").fillMaxWidth().constrainAs(eventList) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In list view + neither search nor filter are active
-        (uiState.viewList) ->
-            EventList(
-                uiState.eventList.allEvents,
-                Modifier.testTag("eventList").fillMaxWidth().constrainAs(eventList) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In map view + search or filter is active
-        (uiState.isSearchActive || uiState.isFilterActive) ->
-            EventMap(
-                uiState.eventList.filteredEvents,
-                Modifier.testTag("filteredMap").fillMaxWidth().constrainAs(eventMap) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In map view + neither search nor filter are active
-        else ->
-            EventMap(
-                uiState.eventList.allEvents,
-                Modifier.testTag("map").fillMaxWidth().constrainAs(eventMap) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-      }
-    } else {
-      when {
-        (!uiState.userLoggedIn) ->
-            Text(
-                "Please log in",
+          if (uiState.tab == Tab.BROWSE) {
+            when {
+              // In list view + search or filter is active
+              (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
+                  EventList(
+                      uiState.eventList.filteredEvents,
+                      Modifier.testTag("filteredEventList").fillMaxWidth().constrainAs(eventList) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In list view + neither search nor filter are active
+              (uiState.viewList) ->
+                  EventList(
+                      uiState.eventList.allEvents,
+                      Modifier.testTag("eventList").fillMaxWidth().constrainAs(eventList) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In map view + search or filter is active
+              (uiState.isSearchActive || uiState.isFilterActive) ->
+                  EventMap(
+                      uiState.eventList.filteredEvents,
+                      Modifier.testTag("filteredMap").fillMaxWidth().constrainAs(eventMap) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In map view + neither search nor filter are active
+              else ->
+                  EventMap(
+                      uiState.eventList.allEvents,
+                      Modifier.testTag("map").fillMaxWidth().constrainAs(eventMap) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+            }
+          } else {
+            when {
+              (!uiState.userLoggedIn) ->
+                  Text(
+                      "Please log in",
+                      modifier =
+                          Modifier.testTag("pleaseLogInText").constrainAs(eventList) {
+                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                          })
+              (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
+                  Text(
+                      "You have no upcoming events",
+                      modifier =
+                          Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
+                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                          })
+              // In list view + search or filter is active
+              (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
+                  EventList(
+                      events = uiState.upcomingEventList.filteredEvents,
+                      modifier =
+                          Modifier.testTag("filteredEventListUpcoming").fillMaxWidth().constrainAs(
+                              eventList) {
+                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                                start.linkTo(parent.start)
+                                end.linkTo(parent.end)
+                              }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In list view + neither search nor filter are active
+              (uiState.viewList) ->
+                  EventList(
+                      events = uiState.upcomingEventList.allEvents,
+                      modifier =
+                          Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(
+                              eventList) {
+                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                                start.linkTo(parent.start)
+                                end.linkTo(parent.end)
+                              }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In map view + search or filter is active
+              (uiState.isSearchActive || uiState.isFilterActive) ->
+                  EventMap(
+                      uiState.upcomingEventList.filteredEvents,
+                      Modifier.testTag("filteredMapUpcoming").fillMaxWidth().constrainAs(eventMap) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+              // In map view + neither search nor filter are active
+              else ->
+                  EventMap(
+                      uiState.upcomingEventList.allEvents,
+                      Modifier.testTag("mapUpcoming").fillMaxWidth().constrainAs(eventMap) {
+                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                      }) { eventId ->
+                        navigationActions.navController.navigate(
+                            "${Route.EVENT_DETAILS}/${eventId}")
+                      }
+            }
+          }
+
+          if (uiState.isFilterDialogOpen) {
+            FilterPopUp(
+                onFreeSwitchChanged = { viewModel.onFreeSwitchChanged() },
+                onFilterApply = { viewModel.onFilterApply() },
+                uiState = uiState,
+                onRadiusQueryChanged = { viewModel.onRadiusQueryChanged(it) },
                 modifier =
-                    Modifier.testTag("pleaseLogInText").constrainAs(eventList) {
-                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                      start.linkTo(parent.start)
-                      end.linkTo(parent.end)
-                    })
-        (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
-            Text(
-                "You have no upcoming events",
-                modifier =
-                    Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
-                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                      start.linkTo(parent.start)
-                      end.linkTo(parent.end)
-                    })
-        // In list view + search or filter is active
-        (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
-            EventList(
-                events = uiState.upcomingEventList.filteredEvents,
-                modifier =
-                    Modifier.testTag("filteredEventListUpcoming").fillMaxWidth().constrainAs(
-                        eventList) {
-                          top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                          start.linkTo(parent.start)
+                    Modifier.height(355.dp).width(230.dp).testTag("filterPopUp").constrainAs(
+                        filterPopUp) {
+                          top.linkTo(searchAndFilter.bottom)
                           end.linkTo(parent.end)
-                        }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In list view + neither search nor filter are active
-        (uiState.viewList) ->
-            EventList(
-                events = uiState.upcomingEventList.allEvents,
-                modifier =
-                    Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(eventList) {
-                      top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                      start.linkTo(parent.start)
-                      end.linkTo(parent.end)
-                    }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In map view + search or filter is active
-        (uiState.isSearchActive || uiState.isFilterActive) ->
-            EventMap(
-                uiState.upcomingEventList.filteredEvents,
-                Modifier.testTag("filteredMapUpcoming").fillMaxWidth().constrainAs(eventMap) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
-        // In map view + neither search nor filter are active
-        else ->
-            EventMap(
-                uiState.upcomingEventList.allEvents,
-                Modifier.testTag("mapUpcoming").fillMaxWidth().constrainAs(eventMap) {
-                  top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                  start.linkTo(parent.start)
-                  end.linkTo(parent.end)
-                }) { eventId ->
-                  navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
-                }
+                        },
+            )
+          }
+        }
       }
-    }
-
-    if (uiState.isFilterDialogOpen) {
-      FilterPopUp(
-          onFreeSwitchChanged = { viewModel.onFreeSwitchChanged() },
-          onFilterApply = { viewModel.onFilterApply() },
-          uiState = uiState,
-          onRadiusQueryChanged = { viewModel.onRadiusQueryChanged(it) },
-          modifier =
-              Modifier.height(355.dp).width(230.dp).testTag("filterPopUp").constrainAs(
-                  filterPopUp) {
-                    top.linkTo(searchAndFilter.bottom)
-                    end.linkTo(parent.end)
-                  },
-      )
-    }
-
-    ViewToggleFab(
-        modifier =
-            Modifier.padding(16.dp).testTag("viewToggleFab").constrainAs(viewToggle) {
-              bottom.linkTo(bottomNav.top)
-              absoluteRight.linkTo(parent.absoluteRight)
-            },
-        onClick = { viewModel.onViewListStatusChanged() },
-        iconVector = getIconFromViewListBool(uiState.viewList))
-
-    BottomNavigationMenu(
-        onTabSelected = { tab -> navigationActions.navigateTo(tab) },
-        tabList = TOP_LEVEL_DESTINATIONS,
-        selectedItem = getTopLevelDestination(Route.HOME),
-        modifier =
-            Modifier.testTag("bottomNavMenu").constrainAs(bottomNav) {
-              bottom.linkTo(parent.bottom)
-              start.linkTo(parent.start)
-              end.linkTo(parent.end)
-            })
-  }
 }
 
 fun getTabIndexFromTabEnum(tab: Tab): Int {

--- a/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/home/Home.kt
@@ -1,15 +1,10 @@
 package com.github.se.eventradar.ui.home
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -19,8 +14,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -29,14 +24,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.github.se.eventradar.ExcludeFromJacocoGeneratedReport
 import com.github.se.eventradar.R
+import com.github.se.eventradar.model.event.Event
 import com.github.se.eventradar.model.repository.event.MockEventRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository
-import com.github.se.eventradar.ui.BottomNavigationMenu
+import com.github.se.eventradar.ui.component.AppScaffold
 import com.github.se.eventradar.ui.component.EventList
 import com.github.se.eventradar.ui.component.FilterPopUp
 import com.github.se.eventradar.ui.component.SearchBarAndFilter
@@ -45,8 +40,8 @@ import com.github.se.eventradar.ui.component.getIconFromViewListBool
 import com.github.se.eventradar.ui.map.EventMap
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
-import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
-import com.github.se.eventradar.ui.navigation.getTopLevelDestination
+import com.github.se.eventradar.util.toast
+import com.github.se.eventradar.viewmodel.EventsOverviewUiState
 import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.viewmodel.Tab
 
@@ -71,44 +66,24 @@ fun HomeScreen(
     }
   }
 
-  Scaffold(
+  AppScaffold(
       modifier = Modifier.testTag("homeScreen"),
-      topBar = {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp).testTag("logo"),
-            verticalAlignment = Alignment.CenterVertically) {
-              Image(
-                  painter = painterResource(id = R.drawable.event_logo),
-                  contentDescription = "Event Radar Logo",
-                  modifier = Modifier.size(width = 186.dp, height = 50.dp))
-            }
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelected = navigationActions::navigateTo,
-            tabList = TOP_LEVEL_DESTINATIONS,
-            selectedItem = getTopLevelDestination(Route.HOME),
-            modifier = Modifier.testTag("bottomNavMenu"))
-      },
       floatingActionButton = {
         ViewToggleFab(
             modifier = Modifier.padding(16.dp).testTag("viewToggleFab"),
             onClick = { viewModel.onViewListStatusChanged() },
             iconVector = getIconFromViewListBool(uiState.viewList))
-      }) {
-        ConstraintLayout(modifier = Modifier.fillMaxSize().padding(it).testTag("homeScreen")) {
-          val (tabs, searchAndFilter, filterPopUp, eventList, eventMap) = createRefs()
+      },
+      navigationActions = navigationActions,
+  ) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(it).padding(top = 16.dp).testTag("homeScreen"),
+        horizontalAlignment = Alignment.CenterHorizontally) {
           TabRow(
               selectedTabIndex = getTabIndexFromTabEnum(uiState.tab),
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .padding(top = 8.dp)
-                      .constrainAs(tabs) {
-                        top.linkTo(parent.top, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }
-                      .testTag("tabs"),
+              modifier = Modifier.fillMaxWidth().testTag("tabs"),
               contentColor = MaterialTheme.colorScheme.primary) {
                 Tab(
                     selected = getTabIndexFromTabEnum(uiState.tab) == 0,
@@ -161,157 +136,74 @@ fun HomeScreen(
               onSearchActiveChanged = { viewModel.onSearchActiveChanged(it) },
               onFilterDialogOpen = { viewModel.onFilterDialogOpen() },
               modifier =
-                  Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                      .testTag("searchBarAndFilter")
-                      .constrainAs(searchAndFilter) {
-                        top.linkTo(tabs.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      },
+                  Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
+                      .testTag("searchBarAndFilter"),
               placeholderStringResource = R.string.home_search_placeholder)
-
-          if (uiState.tab == Tab.BROWSE) {
-            when {
-              // In list view + search or filter is active
-              (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
-                  EventList(
-                      uiState.eventList.filteredEvents,
-                      Modifier.testTag("filteredEventList").fillMaxWidth().constrainAs(eventList) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In list view + neither search nor filter are active
-              (uiState.viewList) ->
-                  EventList(
-                      uiState.eventList.allEvents,
-                      Modifier.testTag("eventList").fillMaxWidth().constrainAs(eventList) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In map view + search or filter is active
-              (uiState.isSearchActive || uiState.isFilterActive) ->
-                  EventMap(
-                      uiState.eventList.filteredEvents,
-                      Modifier.testTag("filteredMap").fillMaxWidth().constrainAs(eventMap) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In map view + neither search nor filter are active
-              else ->
-                  EventMap(
-                      uiState.eventList.allEvents,
-                      Modifier.testTag("map").fillMaxWidth().constrainAs(eventMap) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-            }
-          } else {
-            when {
-              (!uiState.userLoggedIn) ->
-                  Text(
-                      "Please log in",
-                      modifier =
-                          Modifier.testTag("pleaseLogInText").constrainAs(eventList) {
-                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-                          })
-              (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
-                  Text(
-                      "You have no upcoming events",
-                      modifier =
-                          Modifier.testTag("noUpcomingEventsText").constrainAs(eventList) {
-                            top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-                          })
-              // In list view + search or filter is active
-              (uiState.viewList && (uiState.isSearchActive || uiState.isFilterActive)) ->
-                  EventList(
-                      events = uiState.upcomingEventList.filteredEvents,
-                      modifier =
-                          Modifier.testTag("filteredEventListUpcoming").fillMaxWidth().constrainAs(
-                              eventList) {
-                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                                start.linkTo(parent.start)
-                                end.linkTo(parent.end)
-                              }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In list view + neither search nor filter are active
-              (uiState.viewList) ->
-                  EventList(
-                      events = uiState.upcomingEventList.allEvents,
-                      modifier =
-                          Modifier.testTag("eventListUpcoming").fillMaxWidth().constrainAs(
-                              eventList) {
-                                top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                                start.linkTo(parent.start)
-                                end.linkTo(parent.end)
-                              }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In map view + search or filter is active
-              (uiState.isSearchActive || uiState.isFilterActive) ->
-                  EventMap(
-                      uiState.upcomingEventList.filteredEvents,
-                      Modifier.testTag("filteredMapUpcoming").fillMaxWidth().constrainAs(eventMap) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-              // In map view + neither search nor filter are active
-              else ->
-                  EventMap(
-                      uiState.upcomingEventList.allEvents,
-                      Modifier.testTag("mapUpcoming").fillMaxWidth().constrainAs(eventMap) {
-                        top.linkTo(searchAndFilter.bottom, margin = 8.dp)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                      }) { eventId ->
-                        navigationActions.navController.navigate(
-                            "${Route.EVENT_DETAILS}/${eventId}")
-                      }
-            }
-          }
 
           if (uiState.isFilterDialogOpen) {
             FilterPopUp(
                 onFreeSwitchChanged = { viewModel.onFreeSwitchChanged() },
-                onFilterApply = { viewModel.onFilterApply() },
+                onFilterApply = {
+                  if (uiState.radiusQuery != "") {
+                    viewModel.onRadiusQueryChanged("")
+                    context.toast("Radius filtering not yet implemented")
+                  }
+                  viewModel.onFilterApply()
+                },
                 uiState = uiState,
                 onRadiusQueryChanged = { viewModel.onRadiusQueryChanged(it) },
-                modifier =
-                    Modifier.height(355.dp).width(230.dp).testTag("filterPopUp").constrainAs(
-                        filterPopUp) {
-                          top.linkTo(searchAndFilter.bottom)
-                          end.linkTo(parent.end)
-                        },
+                modifier = Modifier.testTag("filterPopUp"),
             )
           }
+
+          EventsOverview(
+              uiState = uiState,
+              navigationActions = navigationActions,
+          )
         }
-      }
+  }
+}
+
+@Composable
+fun EventsOverview(
+    uiState: EventsOverviewUiState,
+    navigationActions: NavigationActions,
+    modifier: Modifier = Modifier
+) {
+  val events = getEventsBasedOffUiState(uiState)
+  if (uiState.tab == Tab.BROWSE) {
+    when (uiState.viewList) {
+      true ->
+          EventList(events, modifier.testTag("eventList").fillMaxWidth()) { eventId ->
+            navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
+          }
+      false ->
+          EventMap(events, modifier.testTag("eventMap").fillMaxWidth()) { eventId ->
+            navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
+          }
+    }
+  } else {
+    when {
+      (!uiState.userLoggedIn) ->
+          Text("Please log in", modifier = modifier.testTag("pleaseLogInText"))
+      (uiState.viewList && uiState.upcomingEventList.allEvents.isEmpty()) ->
+          Text(
+              "You have no upcoming events",
+              textAlign = TextAlign.Center,
+              modifier = modifier.testTag("noUpcomingEventsText"))
+      // In list view + search or filter is active
+      uiState.viewList ->
+          EventList(
+              events = events, modifier = modifier.testTag("eventListUpcoming").fillMaxWidth()) {
+                  eventId ->
+                navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
+              }
+      else ->
+          EventMap(events, modifier.testTag("eventMapUpcoming").fillMaxWidth()) { eventId ->
+            navigationActions.navController.navigate("${Route.EVENT_DETAILS}/${eventId}")
+          }
+    }
+  }
 }
 
 fun getTabIndexFromTabEnum(tab: Tab): Int {
@@ -322,6 +214,20 @@ fun getTabIndexFromTabEnum(tab: Tab): Int {
         1
       }
   return selectedTabIndex
+}
+
+fun getEventsBasedOffUiState(uiState: EventsOverviewUiState): List<Event> {
+  return if (uiState.tab == Tab.BROWSE) {
+    when {
+      uiState.isSearchActive || uiState.isFilterActive -> uiState.eventList.filteredEvents
+      else -> uiState.eventList.allEvents
+    }
+  } else {
+    when {
+      uiState.isSearchActive || uiState.isFilterActive -> uiState.upcomingEventList.filteredEvents
+      else -> uiState.upcomingEventList.allEvents
+    }
+  }
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/app/src/main/res/values/strings_event.xml
+++ b/app/src/main/res/values/strings_event.xml
@@ -4,6 +4,8 @@
     <string name="event_location">Location</string>
     <string name="event_distance">Distance</string>
     <string name="event_date_and_time">Date and time</string>
+    <string name="event_date">Date</string>
+    <string name="event_time">Time</string>
     <string name="event_dt_start">Start</string>
     <string name="event_dt_end">End</string>
     <string name="event_categories">Categories</string>


### PR DESCRIPTION
## Objective
- remove the boilerplate associated with using a constraint layout and use scaffold instead

## Key Changes
- [ ] use scaffold layout in Event Details instead of constraint layout
- [ ] reformat Event Details to match the Figma
- [ ] surround constraint layout in Home with scaffold layout and move bottom and top bars into the scaffold constructor
- [ ] update tests where needed

## Demo
<img src=https://github.com/swent-sp-2024-event-radar/event-radar-app/assets/64320145/d9600db0-22bc-4515-ac86-70c19ebba126 width=400>

closes #264 