### PR TITLE
Private chat screen - bug fixes + refine messages repo

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/chat/ChatTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/chat/ChatTest.kt
@@ -135,7 +135,6 @@ class ChatTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppor
         }
 
         chatScreenMessagesList { assertIsDisplayed() }
-        bottomNav { assertIsDisplayed() }
 
         chatInput { assertIsDisplayed() }
         chatInputField { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/ChatScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/ChatScreen.kt
@@ -17,7 +17,6 @@ public class ChatScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   private val chatScreenColumn: KNode = child { hasTestTag("chatScreenColumn") }
   val chatScreenMessagesList: KNode =
       chatScreenColumn.child { hasTestTag("chatScreenMessagesList") }
-  val bottomNav: KNode = child { hasTestTag("bottomNavMenu") }
 
   val chatInput: KNode = chatScreenColumn.child { hasTestTag("chatInput") }
   val chatInputField: KNode = chatInput.child { hasTestTag("chatInputField") }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name="com.github.se.eventradar.ui.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.MyApplication">
+            android:theme="@style/Theme.MyApplication"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
@@ -39,6 +39,9 @@ fun BottomNavigationMenu(
     selectedItem: TopLevelDestination,
     modifier: Modifier = Modifier,
 ) {
+  val isKeyboardOpen by keyboardAsState() // Keyboard.Opened or Keyboard.Closed
+
+  if (isKeyboardOpen == Keyboard.Closed) {
     BottomNavigation(
         backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
         modifier = modifier,
@@ -81,6 +84,7 @@ fun BottomNavigationMenu(
                         }))
       }
     }
+  }
 }
 
 @Composable
@@ -93,4 +97,35 @@ fun NavBarIcon(tab: TopLevelDestination, modifier: Modifier, iconColor: Color) {
         modifier = Modifier.width(24.dp).height(24.dp),
     )
   }
+}
+
+enum class Keyboard {
+  Opened,
+  Closed
+}
+
+@Composable
+fun keyboardAsState(): State<Keyboard> {
+  val keyboardState = remember { mutableStateOf(Keyboard.Closed) }
+  val view = LocalView.current
+  DisposableEffect(view) {
+    val onGlobalListener =
+        ViewTreeObserver.OnGlobalLayoutListener {
+          val rect = Rect()
+          view.getWindowVisibleDisplayFrame(rect)
+          val screenHeight = view.rootView.height
+          val keypadHeight = screenHeight - rect.bottom
+          keyboardState.value =
+              if (keypadHeight > screenHeight * 0.15) {
+                Keyboard.Opened
+              } else {
+                Keyboard.Closed
+              }
+        }
+    view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+
+    onDispose { view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener) }
+  }
+
+  return keyboardState
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
@@ -1,5 +1,7 @@
 package com.github.se.eventradar.ui
 
+import android.graphics.Rect
+import android.view.ViewTreeObserver
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -11,10 +13,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,46 +39,50 @@ fun BottomNavigationMenu(
     selectedItem: TopLevelDestination,
     modifier: Modifier = Modifier,
 ) {
-  BottomNavigation(
-      backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
-      modifier = modifier,
-  ) {
-    tabList.forEach { tab ->
-      val boxModifier =
-          if (tab == selectedItem) {
-            Modifier.clip(shape = RoundedCornerShape(50))
-                .background(MaterialTheme.colorScheme.primary)
-                .width(58.dp)
-                .height(36.dp)
-          } else Modifier
+  val isKeyboardOpen by keyboardAsState() // Keyboard.Opened or Keyboard.Closed
 
-      val labelText = if (selectedItem == tab) stringResource(tab.textId) else ""
+  if (isKeyboardOpen == Keyboard.Closed) {
+    BottomNavigation(
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = modifier,
+    ) {
+      tabList.forEach { tab ->
+        val boxModifier =
+            if (tab == selectedItem) {
+              Modifier.clip(shape = RoundedCornerShape(50))
+                  .background(MaterialTheme.colorScheme.primary)
+                  .width(58.dp)
+                  .height(36.dp)
+            } else Modifier
 
-      val iconColor =
-          if (selectedItem == tab) MaterialTheme.colorScheme.onPrimary
-          else MaterialTheme.colorScheme.onSurfaceVariant
+        val labelText = if (selectedItem == tab) stringResource(tab.textId) else ""
 
-      BottomNavigationItem(
-          icon = { NavBarIcon(tab, boxModifier, iconColor) },
-          label = {
-            Text(
-                text = labelText,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 11.sp)
-          },
-          selected = selectedItem == tab,
-          onClick = { onTabSelected(tab) },
-          modifier =
-              Modifier.align(Alignment.CenterVertically)
-                  .testTag(
-                      when (tab.textId) {
-                        R.string.scan_QR -> "scanQRBottomNav"
-                        R.string.message_chats -> "messageChatBottomNav"
-                        R.string.homeScreen_events -> "homeScreenEventBottomNav"
-                        R.string.user_profile -> "userProfileBottomNav"
-                        R.string.hosting -> "myHostingBottomNav"
-                        else -> "itemBottomNav"
-                      }))
+        val iconColor =
+            if (selectedItem == tab) MaterialTheme.colorScheme.onPrimary
+            else MaterialTheme.colorScheme.onSurfaceVariant
+
+        BottomNavigationItem(
+            icon = { NavBarIcon(tab, boxModifier, iconColor) },
+            label = {
+              Text(
+                  text = labelText,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  fontSize = 11.sp)
+            },
+            selected = selectedItem == tab,
+            onClick = { onTabSelected(tab) },
+            modifier =
+                Modifier.align(Alignment.CenterVertically)
+                    .testTag(
+                        when (tab.textId) {
+                          R.string.scan_QR -> "scanQRBottomNav"
+                          R.string.message_chats -> "messageChatBottomNav"
+                          R.string.homeScreen_events -> "homeScreenEventBottomNav"
+                          R.string.user_profile -> "userProfileBottomNav"
+                          R.string.hosting -> "myHostingBottomNav"
+                          else -> "itemBottomNav"
+                        }))
+      }
     }
   }
 }
@@ -84,4 +97,35 @@ fun NavBarIcon(tab: TopLevelDestination, modifier: Modifier, iconColor: Color) {
         modifier = Modifier.width(24.dp).height(24.dp),
     )
   }
+}
+
+enum class Keyboard {
+  Opened,
+  Closed
+}
+
+@Composable
+fun keyboardAsState(): State<Keyboard> {
+  val keyboardState = remember { mutableStateOf(Keyboard.Closed) }
+  val view = LocalView.current
+  DisposableEffect(view) {
+    val onGlobalListener =
+        ViewTreeObserver.OnGlobalLayoutListener {
+          val rect = Rect()
+          view.getWindowVisibleDisplayFrame(rect)
+          val screenHeight = view.rootView.height
+          val keypadHeight = screenHeight - rect.bottom
+          keyboardState.value =
+              if (keypadHeight > screenHeight * 0.15) {
+                Keyboard.Opened
+              } else {
+                Keyboard.Closed
+              }
+        }
+    view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+
+    onDispose { view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener) }
+  }
+
+  return keyboardState
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
@@ -39,9 +39,6 @@ fun BottomNavigationMenu(
     selectedItem: TopLevelDestination,
     modifier: Modifier = Modifier,
 ) {
-  val isKeyboardOpen by keyboardAsState() // Keyboard.Opened or Keyboard.Closed
-
-  if (isKeyboardOpen == Keyboard.Closed) {
     BottomNavigation(
         backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
         modifier = modifier,
@@ -84,7 +81,6 @@ fun BottomNavigationMenu(
                         }))
       }
     }
-  }
 }
 
 @Composable
@@ -97,35 +93,4 @@ fun NavBarIcon(tab: TopLevelDestination, modifier: Modifier, iconColor: Color) {
         modifier = Modifier.width(24.dp).height(24.dp),
     )
   }
-}
-
-enum class Keyboard {
-  Opened,
-  Closed
-}
-
-@Composable
-fun keyboardAsState(): State<Keyboard> {
-  val keyboardState = remember { mutableStateOf(Keyboard.Closed) }
-  val view = LocalView.current
-  DisposableEffect(view) {
-    val onGlobalListener =
-        ViewTreeObserver.OnGlobalLayoutListener {
-          val rect = Rect()
-          view.getWindowVisibleDisplayFrame(rect)
-          val screenHeight = view.rootView.height
-          val keypadHeight = screenHeight - rect.bottom
-          keyboardState.value =
-              if (keypadHeight > screenHeight * 0.15) {
-                Keyboard.Opened
-              } else {
-                Keyboard.Closed
-              }
-        }
-    view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
-
-    onDispose { view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener) }
-  }
-
-  return keyboardState
 }

--- a/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
@@ -47,9 +47,9 @@ import com.github.se.eventradar.model.User
 import com.github.se.eventradar.model.message.Message
 import com.github.se.eventradar.model.message.MessageHistory
 import com.github.se.eventradar.ui.component.ProfilePic
+import com.github.se.eventradar.ui.keyboardAsState
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
-import com.github.se.eventradar.ui.navigation.TopLevelDestination
 import com.github.se.eventradar.viewmodel.ChatUiState
 import com.github.se.eventradar.viewmodel.ChatViewModel
 import java.time.LocalDateTime
@@ -61,7 +61,6 @@ fun ChatScreen(viewModel: ChatViewModel, navigationActions: NavigationActions) {
   ChatScreenUi(
       uiState = uiState,
       onBackArrowClick = navigationActions::goBack,
-      onTabSelected = navigationActions::navigateTo,
       onViewProfileClick = navigationActions.navController::navigate,
       onMessageChange = viewModel::onMessageBarInputChange,
       onMessageSend = viewModel::onMessageSend)
@@ -71,7 +70,6 @@ fun ChatScreen(viewModel: ChatViewModel, navigationActions: NavigationActions) {
 fun ChatScreenUi(
     uiState: ChatUiState,
     onBackArrowClick: () -> Unit,
-    onTabSelected: (TopLevelDestination) -> Unit,
     onViewProfileClick: (String) -> Unit,
     onMessageChange: (String) -> Unit,
     onMessageSend: () -> Unit,
@@ -83,8 +81,9 @@ fun ChatScreenUi(
   val opponentPictureUrl = uiState.opponentProfile.profilePicUrl
   val opponentUserId = uiState.opponentProfile.userId
   val scrollState = rememberLazyListState(initialFirstVisibleItemIndex = messages.size)
+  val isKeyboardOpen by keyboardAsState() // Keyboard.Opened or Keyboard.Closed
 
-  LaunchedEffect(key1 = messages.size) {
+  LaunchedEffect(key1 = messages.size, key2 = isKeyboardOpen) {
     if (messages.isNotEmpty()) {
       scrollState.animateScrollToItem(index = messages.size - 1)
     }
@@ -293,7 +292,6 @@ fun ChatScreenPreview() {
   ChatScreenUi(
       uiState = sampleUiState,
       onBackArrowClick = {},
-      onTabSelected = {},
       onMessageChange = {},
       onViewProfileClick = {},
       onMessageSend = {})

--- a/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
@@ -103,13 +103,7 @@ fun ChatScreenUi(
             onBackArrowClick = onBackArrowClick,
         )
       },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelected = onTabSelected,
-            tabList = TOP_LEVEL_DESTINATIONS,
-            selectedItem = TOP_LEVEL_DESTINATIONS[1],
-            modifier = Modifier.testTag("bottomNavMenu"))
-      }) {
+  ) {
         Column(
             modifier =
                 Modifier.padding(it)

--- a/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/chat/Chat.kt
@@ -46,11 +46,9 @@ import com.github.se.eventradar.R
 import com.github.se.eventradar.model.User
 import com.github.se.eventradar.model.message.Message
 import com.github.se.eventradar.model.message.MessageHistory
-import com.github.se.eventradar.ui.BottomNavigationMenu
 import com.github.se.eventradar.ui.component.ProfilePic
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
-import com.github.se.eventradar.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.github.se.eventradar.ui.navigation.TopLevelDestination
 import com.github.se.eventradar.viewmodel.ChatUiState
 import com.github.se.eventradar.viewmodel.ChatViewModel
@@ -104,39 +102,39 @@ fun ChatScreenUi(
         )
       },
   ) {
-        Column(
-            modifier =
-                Modifier.padding(it)
-                    .fillMaxSize()
-                    .focusable()
-                    .wrapContentHeight()
-                    .imePadding()
-                    .testTag("chatScreenColumn")) {
-              LazyColumn(
-                  modifier = Modifier.weight(1f).fillMaxWidth().testTag("chatScreenMessagesList"),
-                  state = scrollState) {
-                    items(messages) { message ->
-                      when (message.sender == uiState.opponentProfile.userId) {
-                        true -> {
-                          ReceivedMessageRow(
-                              text = message.content,
-                          )
-                        }
-                        false -> {
-                          SentMessageRow(
-                              text = message.content,
-                          )
-                        }
-                      }
+    Column(
+        modifier =
+            Modifier.padding(it)
+                .fillMaxSize()
+                .focusable()
+                .wrapContentHeight()
+                .imePadding()
+                .testTag("chatScreenColumn")) {
+          LazyColumn(
+              modifier = Modifier.weight(1f).fillMaxWidth().testTag("chatScreenMessagesList"),
+              state = scrollState) {
+                items(messages) { message ->
+                  when (message.sender == uiState.opponentProfile.userId) {
+                    true -> {
+                      ReceivedMessageRow(
+                          text = message.content,
+                      )
+                    }
+                    false -> {
+                      SentMessageRow(
+                          text = message.content,
+                      )
                     }
                   }
-              ChatInput(
-                  uiState = uiState,
-                  onMessageChange = onMessageChange,
-                  onMessageSend = onMessageSend,
-              )
-            }
-      }
+                }
+              }
+          ChatInput(
+              uiState = uiState,
+              onMessageChange = onMessageChange,
+              onMessageSend = onMessageSend,
+          )
+        }
+  }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/ChatViewModel.kt
@@ -107,18 +107,7 @@ constructor(
           }
           is Resource.Failure -> {
             Log.d("ChatViewModel", "Failed to fetch messages: ${resource.throwable.message}")
-            _uiState.update { currentState
-              -> // Following the current logic in getMessages, may be updated
-              currentState.copy(
-                  messageHistory =
-                      MessageHistory(
-                          user1 = userId,
-                          user2 = opponentId,
-                          latestMessageId = "",
-                          user1ReadMostRecentMessage = false,
-                          user2ReadMostRecentMessage = false,
-                          messages = mutableListOf()))
-            }
+            _uiState.update { currentState -> currentState }
           }
         }
       }
@@ -140,19 +129,7 @@ constructor(
           }
           is Resource.Failure -> {
             Log.d("ChatViewModel", "Error fetching messages: ${messagesResource.throwable.message}")
-
-            // Message history doesn't exist between two users.
-            // Record an empty message history with the two user id's,
-            // so that a new message history can be created for them when addMessage is called
-            currentState.copy(
-                messageHistory =
-                    MessageHistory(
-                        user1 = userId,
-                        user2 = opponentId,
-                        latestMessageId = "",
-                        user1ReadMostRecentMessage = false,
-                        user2ReadMostRecentMessage = false,
-                        messages = mutableListOf()))
+            currentState
           }
         }
       }

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
@@ -47,11 +47,17 @@ constructor(
     viewModelScope.launch {
       when (val response = messagesRepository.getMessages(_uiState.value.userId!!)) {
         is Resource.Success -> {
-          // sort message list by timestamp of latest message for each message history
+          // Filter the message histories to include only those with non-empty messages
+          val filteredMessageList = response.data.filter { it.messages.isNotEmpty() }
+
+          // Sort the filtered message list by timestamp of the latest message for each message
+          // history
           val sortedMessageList =
-              response.data.sortedByDescending {
+              filteredMessageList.sortedByDescending {
                 it.messages.find { message -> message.id == it.latestMessageId }?.dateTimeSent
               }
+
+          // Update the UI state with the sorted and filtered message list
           _uiState.value = _uiState.value.copy(messageList = sortedMessageList)
         }
         is Resource.Failure -> {

--- a/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
@@ -313,12 +313,13 @@ class ChatViewModelUnitTest {
 
     val expectedMH =
         MessageHistory(
-            user1 = "Default sender",
-            user2 = "Default recipient",
-            latestMessageId = "DefaultId",
+            user1 = "user1",
+            user2 = "user2",
+            latestMessageId = "",
             user1ReadMostRecentMessage = false,
             user2ReadMostRecentMessage = false,
-            messages = mutableListOf())
+            messages = mutableListOf(),
+            id = "0")
 
     verify { Log.d("ChatViewModel", expectedLogMessage) }
     assert(viewModel.uiState.value.messageHistory == expectedMH)

--- a/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
@@ -18,7 +18,6 @@ import java.time.LocalDateTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -175,8 +174,6 @@ class ChatViewModelUnitTest {
 
     viewModel =
         ChatViewModel(messageRepository, userRepository, opponentId) // Initialize view model
-
-    runBlocking { viewModel.getMessages() }
 
     val expectedMessages = mutableListOf(msg1, msg2)
     val uiState = viewModel.uiState.value

--- a/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
@@ -167,13 +167,11 @@ class ChatViewModelUnitTest {
     val msg1 = mockMessage.copy(sender = "user1", id = "msg1")
     val msg2 = mockMessage.copy(sender = "user2", id = "msg2")
 
-    val messageHistory = messageRepository.createNewMessageHistory("user1", "user2")
-    val editedMH = (messageHistory as Resource.Success).data
+    val resource = messageRepository.createNewMessageHistory("user1", "user2")
+    val messageHistory = (resource as Resource.Success).data
 
-      messageRepository.addMessage(msg1, editedMH)
-      var uiState = viewModel.uiState.value
-      messageRepository.addMessage(msg2, uiState.messageHistory)
-      uiState = viewModel.uiState.value
+    messageRepository.addMessage(msg1, messageHistory)
+    messageRepository.addMessage(msg2, messageHistory)
 
     viewModel =
         ChatViewModel(messageRepository, userRepository, opponentId) // Initialize view model
@@ -181,6 +179,7 @@ class ChatViewModelUnitTest {
     runBlocking { viewModel.getMessages() }
 
     val expectedMessages = mutableListOf(msg1, msg2)
+    val uiState = viewModel.uiState.value
     assert(expectedMessages == uiState.messageHistory.messages)
   }
 
@@ -196,7 +195,8 @@ class ChatViewModelUnitTest {
     viewModel.getMessages()
 
     verify {
-      Log.d("ChatViewModel", "Error fetching messages: No message history found between users")
+      Log.d(
+          "ChatViewModel", "Failed to fetch messages: No message history found for specified users")
     }
     unmockkAll()
   }
@@ -226,11 +226,10 @@ class ChatViewModelUnitTest {
 
     val msg1 = mockMessage.copy(sender = "user1", id = "msg1")
 
-    val messageHistory = messageRepository.createNewMessageHistory("user1", "user2")
+    val resource = messageRepository.createNewMessageHistory("user1", "user2")
+    val messageHistory = (resource as Resource.Success).data
 
-    val editedMH = (messageHistory as Resource.Success).data
-
-    messageRepository.addMessage(msg1, editedMH)
+    messageRepository.addMessage(msg1, messageHistory)
 
     viewModel =
         ChatViewModel(messageRepository, userRepository, opponentId) // Initialize view model
@@ -293,7 +292,7 @@ class ChatViewModelUnitTest {
     val expected = messageRepository.getMessages("user1", "user2")
 
     (messageRepository as MockMessageRepository).messagesFlow.emit(expected)
-x
+
     assert(viewModel.uiState.value.messageHistory == (expected as Resource.Success).data)
   }
 

--- a/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
@@ -167,14 +167,13 @@ class ChatViewModelUnitTest {
     val msg1 = mockMessage.copy(sender = "user1", id = "msg1")
     val msg2 = mockMessage.copy(sender = "user2", id = "msg2")
 
-    // TODO: clean up logic with add message
     val messageHistory = messageRepository.createNewMessageHistory("user1", "user2")
-
     val editedMH = (messageHistory as Resource.Success).data
 
-    editedMH.messages.add(msg1)
-
-    messageRepository.addMessage(msg2, editedMH)
+      messageRepository.addMessage(msg1, editedMH)
+      var uiState = viewModel.uiState.value
+      messageRepository.addMessage(msg2, uiState.messageHistory)
+      uiState = viewModel.uiState.value
 
     viewModel =
         ChatViewModel(messageRepository, userRepository, opponentId) // Initialize view model
@@ -182,7 +181,6 @@ class ChatViewModelUnitTest {
     runBlocking { viewModel.getMessages() }
 
     val expectedMessages = mutableListOf(msg1, msg2)
-    val uiState = viewModel.uiState.value
     assert(expectedMessages == uiState.messageHistory.messages)
   }
 
@@ -232,7 +230,7 @@ class ChatViewModelUnitTest {
 
     val editedMH = (messageHistory as Resource.Success).data
 
-    editedMH.messages.add(msg1)
+    messageRepository.addMessage(msg1, editedMH)
 
     viewModel =
         ChatViewModel(messageRepository, userRepository, opponentId) // Initialize view model
@@ -281,40 +279,21 @@ class ChatViewModelUnitTest {
     val msg1 = mockMessage.copy(sender = "user1", id = "msg1")
     val msg2 = mockMessage.copy(sender = "user2", id = "msg2")
 
-    val messageHistory = messageRepository.createNewMessageHistory("user1", "user2")
+    val resource = messageRepository.createNewMessageHistory("user1", "user2")
 
-    val editedMH = (messageHistory as Resource.Success).data
+    val messageHistory = (resource as Resource.Success).data
 
-    editedMH.messages.add(msg1)
-
-    // Init calls observeMessages()
-    viewModel = ChatViewModel(messageRepository, userRepository, opponentId)
-
-    messageRepository.addMessage(msg2, editedMH)
-
-    val expected = messageRepository.getMessages("user1", "user2")
-
-    (messageRepository as MockMessageRepository).messagesFlow.emit(expected)
-
-    assert(viewModel.uiState.value.messageHistory == (expected as Resource.Success).data)
-  }
-
-  @Test
-  fun `observeMessages Success No Existing Message History`() = runTest {
-    (userRepository as MockUserRepository).updateCurrentUserId("user1")
-    userRepository.addUser(opponent)
-
-    val messageHistory = messageRepository.createNewMessageHistory("user1", "user2")
-
-    val editedMH = (messageHistory as Resource.Success).data
+    messageRepository.addMessage(msg1, messageHistory)
 
     // Init calls observeMessages()
     viewModel = ChatViewModel(messageRepository, userRepository, opponentId)
 
+    messageRepository.addMessage(msg2, messageHistory)
+
     val expected = messageRepository.getMessages("user1", "user2")
 
     (messageRepository as MockMessageRepository).messagesFlow.emit(expected)
-
+x
     assert(viewModel.uiState.value.messageHistory == (expected as Resource.Success).data)
   }
 

--- a/app/src/test/java/com/github/se/eventradar/FirebaseMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/FirebaseMessageRepositoryUnitTest.kt
@@ -168,10 +168,24 @@ class FirebaseMessageRepositoryUnitTest {
     every { messagesRef.where(any()).limit(1).get() } returns mockTask(mockQuerySnapshot)
     every { mockQuerySnapshot.isEmpty } returns true
 
+    every { messagesRef.add(any()) } returns mockTask(mockDocumentReference)
+    every { mockDocumentReference.id } returns "1"
+
     val result = firebaseMessageRepository.getMessages(uid, "2")
-    val exceptionMessage = ("No message history found between users")
-    assert(result is Resource.Failure)
-    assert((result as Resource.Failure).throwable.message == exceptionMessage)
+
+    val expectedMH =
+        MessageHistory(
+            user1 = uid,
+            user2 = "2",
+            latestMessageId = "",
+            user1ReadMostRecentMessage = false,
+            user2ReadMostRecentMessage = false,
+            messages = mutableListOf(),
+            id = "1")
+
+    assert(result is Resource.Success)
+    val returnedMessageHistory = (result as Resource.Success).data
+    assert(returnedMessageHistory == expectedMH)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/eventradar/FirebaseMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/FirebaseMessageRepositoryUnitTest.kt
@@ -334,10 +334,10 @@ class FirebaseMessageRepositoryUnitTest {
     // Execute the addMessage function
     val result = firebaseMessageRepository.addMessage(message, emptyMessageHistory)
 
-    // Assert successful addition and correct message history creation
+    // Assert successful addition
     assert(result is Resource.Success)
     assert(captureUpdate.captured == expectedUpdateValues)
-    assert(emptyMessageHistory.id == newMessageHistoryId) // Check if the ID was set correctly
+    assert(emptyMessageHistory.id == newMessageHistoryId)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
@@ -36,65 +36,63 @@ class MockMessageRepositoryUnitTest {
     assert(messageHistory is Resource.Success)
 
     messageHistory = messageHistory as Resource.Success
-      assert(messageHistory.data.user1 == "1")
-      assert(messageHistory.data.user2 == "2")
+    assert(messageHistory.data.user1 == "1")
+    assert(messageHistory.data.user2 == "2")
   }
 
   @Test
   fun testGetMessagesReturnsAlreadyCreatedMessageHistory() = runTest {
     // Test getMessages() method
-      var messageHistory = messageRepository.getMessages("1", "2")
-      assert(messageHistory is Resource.Success)
+    var messageHistory = messageRepository.getMessages("1", "2")
+    assert(messageHistory is Resource.Success)
 
-      messageHistory = messageHistory as Resource.Success
+    messageHistory = messageHistory as Resource.Success
 
-      val messageHistoryId = messageHistory.data.id
+    val messageHistoryId = messageHistory.data.id
 
-      messageHistory = messageRepository.getMessages("1", "2")
+    messageHistory = messageRepository.getMessages("1", "2")
 
     assert(messageHistory is Resource.Success)
 
-      assert((messageHistory as Resource.Success).data.id == messageHistoryId)
+    assert((messageHistory as Resource.Success).data.id == messageHistoryId)
   }
 
   @Test
   fun testAddMessage() = runTest {
-      // Test addMessage() method
-      var messageHistory = messageRepository.getMessages("1", "2")
+    // Test addMessage() method
+    var messageHistory = messageRepository.getMessages("1", "2")
 
-      assert(messageHistory is Resource.Success)
+    assert(messageHistory is Resource.Success)
 
-      messageHistory = messageHistory as Resource.Success
+    messageHistory = messageHistory as Resource.Success
 
-      val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
 
     assert(addMessage is Resource.Success)
 
-      assert(messageHistory.data.messages[0] == mockMessage)
-      assert(messageHistory.data.latestMessageId == "1")
+    assert(messageHistory.data.messages[0] == mockMessage)
+    assert(messageHistory.data.latestMessageId == "1")
   }
 
   @Test
   fun testUpdateMessage() = runTest {
-      // Test updateMessage() method
-      var messageHistory = messageRepository.getMessages("1", "2")
+    // Test updateMessage() method
+    var messageHistory = messageRepository.getMessages("1", "2")
 
-      assert(messageHistory is Resource.Success)
+    assert(messageHistory is Resource.Success)
 
-      messageHistory = messageHistory as Resource.Success
+    messageHistory = messageHistory as Resource.Success
 
-
-      val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
-
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
 
     assert(addMessage is Resource.Success)
 
-      val updateMessage = messageRepository.updateReadStateForUser("1", messageHistory.data)
+    val updateMessage = messageRepository.updateReadStateForUser("1", messageHistory.data)
 
     assert(updateMessage is Resource.Success)
 
-      assert(messageHistory.data.user1ReadMostRecentMessage)
-      assert(!messageHistory.data.user2ReadMostRecentMessage)
+    assert(messageHistory.data.user1ReadMostRecentMessage)
+    assert(!messageHistory.data.user2ReadMostRecentMessage)
   }
 
   @Test
@@ -156,13 +154,13 @@ class MockMessageRepositoryUnitTest {
 
   @Test
   fun addMessageUpdatesMessageHistoryWhenNewMessageIsReceived() = runTest {
-      var messageHistory = messageRepository.getMessages("1", "2")
+    var messageHistory = messageRepository.getMessages("1", "2")
 
-      assert(messageHistory is Resource.Success)
+    assert(messageHistory is Resource.Success)
 
-      messageHistory = messageHistory as Resource.Success
+    messageHistory = messageHistory as Resource.Success
 
-      val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
+    val addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
 
     assert(addMessage is Resource.Success)
 
@@ -171,7 +169,7 @@ class MockMessageRepositoryUnitTest {
 
     assert(addSecondMessage is Resource.Success)
 
-      messageHistory = messageRepository.getMessages("1", "2")
+    messageHistory = messageRepository.getMessages("1", "2")
 
     assert(messageHistory is Resource.Success)
 
@@ -220,11 +218,11 @@ class MockMessageRepositoryUnitTest {
     val user1 = "1"
     val user2 = "2"
 
-      var messageHistory = messageRepository.getMessages("1", "2")
+    var messageHistory = messageRepository.getMessages("1", "2")
 
-      assert(messageHistory is Resource.Success)
+    assert(messageHistory is Resource.Success)
 
-      messageHistory = messageHistory as Resource.Success
+    messageHistory = messageHistory as Resource.Success
 
     var addMessage = messageRepository.addMessage(mockMessage, messageHistory.data)
 

--- a/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MockMessageRepositoryUnitTest.kt
@@ -38,6 +38,9 @@ class MockMessageRepositoryUnitTest {
     messageHistory = messageHistory as Resource.Success
     assert(messageHistory.data.user1 == "1")
     assert(messageHistory.data.user2 == "2")
+    assert(!messageHistory.data.user1ReadMostRecentMessage)
+    assert(!messageHistory.data.user2ReadMostRecentMessage)
+    assert(messageHistory.data.messages.isEmpty())
   }
 
   @Test


### PR DESCRIPTION
Main changes:
- Fixed the bloody nasty bug where top app bar wasn't showing when keyboard typing in message bar by:
   - Changing app visibility when keyboard is open to squish screen size and display all elements 
   - This meant creating a new state and only displaying the bottom nav bar if they keyboard was not open
- Refined Message Repositories logic (Firebase + Mock) for `getMessages()` for 2 users, `addMessage()`, `createNewMessageHistory()`
- Changed associated tests in `FirebaseMessageRepositoryUnitTest.kt` `MockMessageRepositoryUnitTest.kt` and `ChatViewModelUnitTest.kt`