### PR TITLE
Change signup DOB separator from "/" to "." 

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/signup/SignupFailureTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/signup/SignupFailureTest.kt
@@ -87,7 +87,7 @@ class SignupFailureTest : TestCase() {
         }
         birthDateTextField {
           performScrollTo()
-          performTextInput("01/01/2000")
+          performTextInput("01.01.2000")
         }
       }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/signup/SignupSuccessTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/signup/SignupSuccessTest.kt
@@ -104,7 +104,7 @@ class SignupSuccessTest : TestCase() {
       birthDateTextField {
         performScrollTo()
         assertIsDisplayed()
-        performTextInput("01/01/2000")
+        performTextInput("01.01.2000")
       }
       sampleSignUpUiState.value = sampleSignUpUiState.value.copy(birthDate = "01/01/2000")
       signUpButton {

--- a/app/src/androidTest/java/com/github/se/eventradar/signup/SignupTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/signup/SignupTest.kt
@@ -110,7 +110,7 @@ class SignupTest : TestCase() {
       birthDateTextField {
         performScrollTo()
         assertIsDisplayed()
-        performTextInput("01/01/2000")
+        performTextInput("01.01.2000")
       }
 
       signUpButton {

--- a/app/src/main/java/com/github/se/eventradar/ui/login/SignUpScreen.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/login/SignUpScreen.kt
@@ -255,7 +255,7 @@ fun SignUpScreen(
           OutlinedTextField(
               value = uiState.birthDate,
               onValueChange = viewModel::onBirthDateChanged,
-              label = { Text("Birth Date (DD/MM/YYYY)") },
+              label = { Text("Birth Date (DD.MM.YYYY)") },
               modifier = Modifier.width(320.dp).testTag("signUpBirthDateTextField"),
               colors =
                   OutlinedTextFieldDefaults.colors()
@@ -263,6 +263,7 @@ fun SignUpScreen(
                           focusedPrefixColor = MaterialTheme.colorScheme.primary,
                           unfocusedPrefixColor = MaterialTheme.colorScheme.primary),
               shape = RoundedCornerShape(12.dp),
+              keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
               isError = uiState.birthDateIsError,
           )
         }

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/AuthenticationViewModel.kt
@@ -13,6 +13,8 @@ import com.google.zxing.qrcode.QRCodeWriter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -214,11 +216,19 @@ class LoginViewModel @Inject constructor(private val userRepository: IUserReposi
   }
 
   private fun isValidDate(date: String): Boolean {
-    val format = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val format = SimpleDateFormat("dd.MM.yyyy", Locale.getDefault())
     format.isLenient = false
     return try {
-      format.parse(date)
-      true
+      val parsedDate = format.parse(date)
+
+      val currentDate = Date()
+      val calendar = Calendar.getInstance()
+      calendar.time = currentDate
+      calendar.add(Calendar.YEAR, -130) // set limit to 130 years ago
+      val pastDateLimit = calendar.time
+
+      // return true if date not null and date is between today and past limit
+      (parsedDate != null && parsedDate.before(currentDate) && parsedDate.after(pastDateLimit))
     } catch (e: Exception) {
       false
     }

--- a/app/src/test/java/com/github/se/eventradar/AuthenticationViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/AuthenticationViewModelTest.kt
@@ -57,10 +57,10 @@ class AuthenticationViewModelTest {
     }
   }
 
-  val mockUser =
+  private val mockUser =
       User(
           userId = "1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@test.com",
           firstName = "John",
           lastName = "Doe",
@@ -99,26 +99,26 @@ class AuthenticationViewModelTest {
 
   @Test
   fun testOnFirstNameChange() = runTest {
-    viewModel.onFirstNameChanged("John", mockUiState)
-    assert(mockUiState.value.firstName == "John")
+    viewModel.onFirstNameChanged(mockUser.firstName, mockUiState)
+    assert(mockUiState.value.firstName == mockUser.firstName)
   }
 
   @Test
   fun testOnLastNameChange() = runTest {
-    viewModel.onLastNameChanged("Doe", mockUiState)
-    assert(mockUiState.value.lastName == "Doe")
+    viewModel.onLastNameChanged(mockUser.lastName, mockUiState)
+    assert(mockUiState.value.lastName == mockUser.lastName)
   }
 
   @Test
   fun testOnUsernameChange() = runTest {
-    viewModel.onUsernameChanged("john_doe", mockUiState)
-    assert(mockUiState.value.username == "john_doe")
+    viewModel.onUsernameChanged(mockUser.username, mockUiState)
+    assert(mockUiState.value.username == mockUser.username)
   }
 
   @Test
   fun testOnBirthDateChange() = runTest {
-    viewModel.onBirthDateChanged("01/01/2000", mockUiState)
-    assert(mockUiState.value.birthDate == "01/01/2000")
+    viewModel.onBirthDateChanged(mockUser.birthDate, mockUiState)
+    assert(mockUiState.value.birthDate == mockUser.birthDate)
   }
 
   @Test
@@ -129,8 +129,8 @@ class AuthenticationViewModelTest {
 
   @Test
   fun testOnPhoneNumberChange() = runTest {
-    viewModel.onPhoneNumberChanged("1234567890", mockUiState)
-    assert(mockUiState.value.phoneNumber == "1234567890")
+    viewModel.onPhoneNumberChanged(mockUser.phoneNumber, mockUiState)
+    assert(mockUiState.value.phoneNumber == mockUser.phoneNumber)
   }
 
   @Test
@@ -141,15 +141,38 @@ class AuthenticationViewModelTest {
 
   @Test
   fun testValidateFieldsForCorrectFields() = runTest {
-    viewModel.onFirstNameChanged("John", mockUiState)
-    viewModel.onLastNameChanged("Doe", mockUiState)
-    viewModel.onUsernameChanged("john_doe", mockUiState)
-    viewModel.onBirthDateChanged("01/01/2000", mockUiState)
+    val swissPhoneNumber = "123456789"
+
+    viewModel.onFirstNameChanged(mockUser.firstName, mockUiState)
+    viewModel.onLastNameChanged(mockUser.lastName, mockUiState)
+    viewModel.onUsernameChanged(mockUser.username, mockUiState)
+    viewModel.onBirthDateChanged(mockUser.birthDate, mockUiState)
     viewModel.onCountryCodeChanged(CountryCode.CH, mockUiState)
-    viewModel.onPhoneNumberChanged("123456789", mockUiState)
+    viewModel.onPhoneNumberChanged(swissPhoneNumber, mockUiState)
     viewModel.onSelectedImageUriChanged(Uri.EMPTY, mockUiState)
 
     assert(viewModel.validateFields(mockUiState))
+  }
+
+  @Test
+  fun testValidateFieldTooOldBirthdate() = runTest {
+
+    // set valid initial state
+    val swissPhoneNumber = "123456789"
+    viewModel.onFirstNameChanged(mockUser.firstName, mockUiState)
+    viewModel.onLastNameChanged(mockUser.lastName, mockUiState)
+    viewModel.onUsernameChanged(mockUser.username, mockUiState)
+    viewModel.onBirthDateChanged(mockUser.birthDate, mockUiState)
+    viewModel.onCountryCodeChanged(CountryCode.CH, mockUiState)
+    viewModel.onPhoneNumberChanged(swissPhoneNumber, mockUiState)
+    viewModel.onSelectedImageUriChanged(Uri.EMPTY, mockUiState)
+    // assert state is valid
+    assert(viewModel.validateFields(mockUiState))
+
+    // change the birthdate with invalid
+    viewModel.onBirthDateChanged("02.09.1000", mockUiState)
+
+    assert(!viewModel.validateFields(mockUiState))
   }
 
   @Test
@@ -157,10 +180,10 @@ class AuthenticationViewModelTest {
 
   @Test
   fun testValidateForPartiallyFilledFields() = runTest {
-    viewModel.onFirstNameChanged("John", mockUiState)
-    viewModel.onLastNameChanged("Doe", mockUiState)
-    viewModel.onUsernameChanged("john_doe", mockUiState)
-    viewModel.onBirthDateChanged("01/01/2000", mockUiState)
+    viewModel.onFirstNameChanged(mockUser.firstName, mockUiState)
+    viewModel.onLastNameChanged(mockUser.lastName, mockUiState)
+    viewModel.onUsernameChanged(mockUser.username, mockUiState)
+    viewModel.onBirthDateChanged(mockUser.birthDate, mockUiState)
     viewModel.onCountryCodeChanged(CountryCode.AU, mockUiState)
 
     assert(!viewModel.validateFields(mockUiState))
@@ -168,12 +191,12 @@ class AuthenticationViewModelTest {
 
   @Test
   fun testAddUser() = runTest {
-    viewModel.onFirstNameChanged("John", mockUiState)
-    viewModel.onLastNameChanged("Doe", mockUiState)
-    viewModel.onUsernameChanged("john_doe", mockUiState)
-    viewModel.onBirthDateChanged("01/01/2000", mockUiState)
+    viewModel.onFirstNameChanged(mockUser.firstName, mockUiState)
+    viewModel.onLastNameChanged(mockUser.lastName, mockUiState)
+    viewModel.onUsernameChanged(mockUser.username, mockUiState)
+    viewModel.onBirthDateChanged(mockUser.birthDate, mockUiState)
     viewModel.onCountryCodeChanged(CountryCode.AU, mockUiState)
-    viewModel.onPhoneNumberChanged("1234567890", mockUiState)
+    viewModel.onPhoneNumberChanged(mockUser.phoneNumber, mockUiState)
     viewModel.onSelectedImageUriChanged(uri, mockUiState)
     // Mocks Sign In From Google, which sets the userId
     (userRepository as MockUserRepository).updateCurrentUserId(mockUser.userId)

--- a/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ChatViewModelUnitTest.kt
@@ -79,7 +79,7 @@ class ChatViewModelUnitTest {
   private val opponent =
       User(
           userId = opponentId,
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/EventDetailsViewmodelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/EventDetailsViewmodelUnitTest.kt
@@ -89,7 +89,7 @@ class EventDetailsViewmodelUnitTest {
   private val mockUser =
       User(
           userId = "user1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/EventOverviewViewModelTest.kt
@@ -72,7 +72,7 @@ class EventsOverviewViewModelTest {
   private val mockUser =
       User(
           userId = "user1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/HostedEventsViewModelTest.kt
@@ -68,7 +68,7 @@ class HostedEventsViewModelTest {
   private val mockUser =
       User(
           userId = "userid1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/MessagesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MessagesViewModelTest.kt
@@ -114,7 +114,7 @@ class MessagesViewModelTest {
         userRepository.addUser(
             User(
                 userId = "1",
-                birthDate = "01/01/2000",
+                birthDate = "01.01.2000",
                 email = "",
                 firstName = "",
                 lastName = "",
@@ -179,7 +179,7 @@ class MessagesViewModelTest {
     val user =
         User(
             userId = "1",
-            birthDate = "01/01/2000",
+            birthDate = "01.01.2000",
             email = "",
             firstName = "",
             lastName = "",
@@ -225,7 +225,7 @@ class MessagesViewModelTest {
     val user =
         User(
             userId = "1",
-            birthDate = "01/01/2000",
+            birthDate = "01.01.2000",
             email = "",
             firstName = "",
             lastName = "",
@@ -269,7 +269,7 @@ class MessagesViewModelTest {
     val user =
         User(
             userId = "1",
-            birthDate = "01/01/2000",
+            birthDate = "01.01.2000",
             email = "",
             firstName = "",
             lastName = "",

--- a/app/src/test/java/com/github/se/eventradar/MockUserRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MockUserRepositoryUnitTest.kt
@@ -18,7 +18,7 @@ class MockUserRepositoryUnitTest {
   private val mockUser =
       User(
           userId = "1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/ScanFriendQrViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ScanFriendQrViewModelTest.kt
@@ -39,7 +39,7 @@ class ScanFriendQrViewModelTest {
   private val mockUser =
       User(
           userId = "1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
@@ -56,7 +56,7 @@ class ScanFriendQrViewModelTest {
   private val mockUser1 =
       User(
           userId = "user1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
@@ -73,7 +73,7 @@ class ScanFriendQrViewModelTest {
   private val mockUser2 =
       User(
           userId = "user2",
-          birthDate = "01/01/2002",
+          birthDate = "01.01.2002",
           email = "test@example2.com",
           firstName = "John2",
           lastName = "Doe2",
@@ -90,7 +90,7 @@ class ScanFriendQrViewModelTest {
   private val mockUser1AF =
       User(
           userId = "user1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
@@ -107,7 +107,7 @@ class ScanFriendQrViewModelTest {
   private val mockUser2AF =
       User(
           userId = "user2",
-          birthDate = "01/01/2002",
+          birthDate = "01.01.2002",
           email = "test@example2.com",
           firstName = "John2",
           lastName = "Doe2",

--- a/app/src/test/java/com/github/se/eventradar/ScanTicketQrViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ScanTicketQrViewModelTest.kt
@@ -60,7 +60,7 @@ class ScanFriendTicketViewModelTest {
   private val mockUser1 =
       User(
           userId = "user1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
@@ -77,7 +77,7 @@ class ScanFriendTicketViewModelTest {
   private val mockUser2 =
       User(
           userId = "user2",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",

--- a/app/src/test/java/com/github/se/eventradar/ViewFriendsProfileViewModelUnitTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/ViewFriendsProfileViewModelUnitTest.kt
@@ -28,7 +28,7 @@ class ViewFriendsProfileViewModelUnitTest {
   private val mockUser =
       User(
           userId = "1",
-          birthDate = "01/01/2000",
+          birthDate = "01.01.2000",
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
@@ -44,7 +44,7 @@ class ViewFriendsProfileViewModelUnitTest {
   private val mockFriend =
       User(
           userId = "2",
-          birthDate = "02/02/2002",
+          birthDate = "02.02.2002",
           email = "friend@example.com",
           firstName = "Jim",
           lastName = "Smith",


### PR DESCRIPTION
# Objective

Reintroduce nummeric keyboard to type date of birth in the signup screen. The "/" wasn't available to type with the nummeric keyboard so it is changed to "." which also makes it more consistent with the how the dates are displayed in the rest of the app.