### PR TITLE
End to end tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     versionCode = 1
     versionName = "1.0"
 
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner = "com.github.se.eventradar.CustomTestRunner"
     vectorDrawables { useSupportLibrary = true }
   }
   

--- a/app/src/androidTest/java/com/github/se/eventradar/CustomTestRunner.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/CustomTestRunner.kt
@@ -1,0 +1,14 @@
+package com.github.se.eventradar
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+// A custom runner to set up the instrumented application class for tests.
+class CustomTestRunner : AndroidJUnitRunner() {
+
+  override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+    return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+  }
+}

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -64,8 +64,6 @@ class UserFlowTests : TestCase() {
   // Relaxed mocks methods have a default implementation returning values
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
 
-  @RelaxedMockK lateinit var mockChatViewModel: ChatViewModel
-
   private var userRepository: IUserRepository = MockUserRepository()
   private var eventRepository: IEventRepository = MockEventRepository()
   private var messageRepository: IMessageRepository = MockMessageRepository()
@@ -326,9 +324,7 @@ class UserFlowTests : TestCase() {
           assertIsDisplayed()
           performTextInput("Test Message 3")
         }
-        mockChatViewModel.onMessageBarInputChange("Test Message 3")
         chatInputSendButton { performClick() }
-        mockChatViewModel.onMessageSend()
       }
 
       step("Check if message is displayed") {
@@ -412,9 +408,7 @@ class UserFlowTests : TestCase() {
           assertIsDisplayed()
           performTextInput("Test Message 3")
         }
-        mockChatViewModel.onMessageBarInputChange("Test Message 3")
         chatInputSendButton { performClick() }
-        mockChatViewModel.onMessageSend()
       }
 
       step("Check if message is displayed") {

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -42,7 +42,6 @@ import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import java.time.LocalDateTime
 import kotlinx.coroutines.runBlocking
@@ -61,8 +60,7 @@ class UserFlowTests : TestCase() {
   // This rule automatically initializes lateinit properties with @MockK, @RelaxedMockK, etc.
   @get:Rule val mockkRule = MockKRule(this)
 
-  // Relaxed mocks methods have a default implementation returning values
-  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+  private lateinit var navActions: NavigationActions
 
   private var userRepository: IUserRepository = MockUserRepository()
   private var eventRepository: IEventRepository = MockEventRepository()
@@ -148,37 +146,37 @@ class UserFlowTests : TestCase() {
     // Launch the Home screen
     composeTestRule.setContent {
       val navController = rememberNavController()
-      mockNavActions = NavigationActions(navController)
+      navActions = NavigationActions(navController)
       MyApplicationTheme {
         NavHost(navController = navController, startDestination = Route.HOME) {
           composable(Route.HOME) {
-            HomeScreen(EventsOverviewViewModel(eventRepository, userRepository), mockNavActions)
+            HomeScreen(EventsOverviewViewModel(eventRepository, userRepository), navActions)
           }
           composable(
               "${Route.EVENT_DETAILS}/{eventId}",
               arguments = listOf(navArgument("eventId") { type = NavType.StringType })) {
                 val eventId = it.arguments!!.getString("eventId")!!
                 EventDetails(
-                    EventDetailsViewModel(eventRepository, userRepository, eventId), mockNavActions)
+                    EventDetailsViewModel(eventRepository, userRepository, eventId), navActions)
               }
           composable(Route.MESSAGE) {
             MessagesScreen(
                 MessagesViewModel(messageRepository, userRepository),
-                navigationActions = mockNavActions)
+                navigationActions = navActions)
           }
           composable(
               "${Route.PRIVATE_CHAT}/{opponentId}",
               arguments = listOf(navArgument("opponentId") { type = NavType.StringType })) {
                 val opponentId = it.arguments!!.getString("opponentId")!!
                 val viewModel = ChatViewModel(messageRepository, userRepository, opponentId)
-                ChatScreen(viewModel = viewModel, navigationActions = mockNavActions)
+                ChatScreen(viewModel = viewModel, navigationActions = navActions)
               }
           composable(
               "${Route.PROFILE}/{friendUserId}",
               arguments = listOf(navArgument("friendUserId") { type = NavType.StringType })) {
                 val friendUserId = it.arguments!!.getString("friendUserId")!!
                 val viewModel = ViewFriendsProfileViewModel(userRepository, friendUserId)
-                ViewFriendsProfileUi(viewModel = viewModel, navigationActions = mockNavActions)
+                ViewFriendsProfileUi(viewModel = viewModel, navigationActions = navActions)
               }
         }
       }

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -17,11 +17,15 @@ import com.github.se.eventradar.model.repository.user.IUserRepository
 import com.github.se.eventradar.model.repository.user.MockUserRepository
 import com.github.se.eventradar.screens.EventDetailsScreen
 import com.github.se.eventradar.screens.HomeScreen
+import com.github.se.eventradar.screens.MessagesScreen
+import com.github.se.eventradar.ui.chat.ChatScreen
 import com.github.se.eventradar.ui.event.EventDetails
 import com.github.se.eventradar.ui.home.HomeScreen
+import com.github.se.eventradar.ui.messages.MessagesScreen
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
 import com.github.se.eventradar.ui.theme.MyApplicationTheme
+import com.github.se.eventradar.viewmodel.ChatViewModel
 import com.github.se.eventradar.viewmodel.EventDetailsViewModel
 import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -36,7 +40,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ViewEventDetailsUserFlow : TestCase() {
+class UserFlowTests : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
 
   // This rule automatic initializes lateinit properties with @MockK, @RelaxedMockK, etc.
@@ -87,6 +91,14 @@ class ViewEventDetailsUserFlow : TestCase() {
                 EventDetails(
                     EventDetailsViewModel(eventRepository, userRepository, eventId), mockNavActions)
               }
+          composable(Route.MESSAGE) { MessagesScreen(navigationActions = mockNavActions) }
+          composable(
+              "${Route.PRIVATE_CHAT}/{opponentId}",
+              arguments = listOf(navArgument("opponentId") { type = NavType.StringType })) {
+                val opponentId = it.arguments!!.getString("opponentId")!!
+                val viewModel = ChatViewModel.create(opponentId = opponentId)
+                ChatScreen(viewModel = viewModel, navigationActions = mockNavActions)
+              }
         }
       }
     }
@@ -134,6 +146,29 @@ class ViewEventDetailsUserFlow : TestCase() {
         dateContent { assertIsDisplayed() }
         timeTitle { assertIsDisplayed() }
         timeContent { assertIsDisplayed() }
+      }
+    }
+  }
+
+  // PATH: homeScreen to Message to friend to start a conversation to send a first message
+
+  @Test
+  fun homeScreenToMessageScreenAndSendFirstMessage() = run {
+    ComposeScreen.onComposeScreen<HomeScreen>(composeTestRule) {
+      step("Check if nav bar and tabs are present") {
+        bottomNav { assertIsDisplayed() }
+        messagesTab { assertIsDisplayed() }
+        homeTab { assertIsDisplayed() }
+      }
+      step("Navigate to messages") {
+        step("Click on the message icon") { messagesTab { performClick() } }
+      }
+    }
+
+    ComposeScreen.onComposeScreen<MessagesScreen>(composeTestRule) {
+      step("Check if all friends are listed") {
+        // Test the UI elements
+
       }
     }
   }

--- a/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/messages/MessagesTest.kt
@@ -70,21 +70,15 @@ class MessagesTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
               username = "Test$i"))
 
       // Add messages to the mock repository (except for the first user)
-      // TODO: fix logic with add message
       if (i > 1) {
         val mh = mockMessageRepository.createNewMessageHistory("1", "$i")
-
-        (mh as Resource.Success)
-            .data
-            .messages
-            .add(
-                Message(
-                    sender = "$i",
-                    content = "Test Message",
-                    dateTimeSent = LocalDateTime.parse("2021-01-01T00:00:00"),
-                    id = "1"),
-            )
-        mh.data.latestMessageId = "1"
+        mockMessageRepository.addMessage(
+            Message(
+                sender = "$i",
+                content = "Test Message",
+                dateTimeSent = LocalDateTime.parse("2021-01-01T00:00:00"),
+                id = "1"),
+            (mh as Resource.Success).data)
       }
     }
 

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
@@ -14,6 +14,8 @@ class HomeScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val browseTab: KNode = tabs.child { hasTestTag("browseTab") }
   val eventCard: KNode = onNode { hasTestTag("eventCard") }
   val bottomNav: KNode = child { hasTestTag("bottomNavMenu") }
+  val homeTab: KNode = bottomNav.child { hasTestTag("homeScreenEventBottomNav") }
+  val messagesTab: KNode = bottomNav.child { hasTestTag("messageChatBottomNav") }
   val viewToggleFab: KNode = child { hasTestTag("viewToggleFab") }
   val map: KNode = child { hasTestTag("eventMap") }
   val eventList: KNode = child { hasTestTag("eventList") }

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.eventradar.screens
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import com.github.se.eventradar.R
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 
@@ -14,8 +15,11 @@ class HomeScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val browseTab: KNode = tabs.child { hasTestTag("browseTab") }
   val eventCard: KNode = onNode { hasTestTag("eventCard") }
   val bottomNav: KNode = child { hasTestTag("bottomNavMenu") }
-  val homeTab: KNode = bottomNav.child { hasTestTag("homeScreenEventBottomNav") }
-  val messagesTab: KNode = bottomNav.child { hasTestTag("messageChatBottomNav") }
+  val homeIcon: KNode = onNode { hasTestTag(R.string.homeScreen_events.toString()) }
+  val messageIcon: KNode = onNode { hasTestTag(R.string.message_chats.toString()) }
+  val qrIcon: KNode = onNode { hasTestTag(R.string.scan_QR.toString()) }
+  val profileIcon: KNode = onNode { hasTestTag(R.string.user_profile.toString()) }
+  val hostingIcon: KNode = onNode { hasTestTag(R.string.hosting.toString()) }
   val viewToggleFab: KNode = child { hasTestTag("viewToggleFab") }
   val map: KNode = child { hasTestTag("eventMap") }
   val eventList: KNode = child { hasTestTag("eventList") }

--- a/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/eventradar/ui/BottomNavigationMenu.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.eventradar.R
 import com.github.se.eventradar.ui.navigation.TopLevelDestination
 
 @Composable
@@ -75,16 +74,7 @@ fun BottomNavigationMenu(
             selected = selectedItem == tab,
             onClick = { onTabSelected(tab) },
             modifier =
-                Modifier.align(Alignment.CenterVertically)
-                    .testTag(
-                        when (tab.textId) {
-                          R.string.scan_QR -> "scanQRBottomNav"
-                          R.string.message_chats -> "messageChatBottomNav"
-                          R.string.homeScreen_events -> "homeScreenEventBottomNav"
-                          R.string.user_profile -> "userProfileBottomNav"
-                          R.string.hosting -> "myHostingBottomNav"
-                          else -> "itemBottomNav"
-                        }))
+                Modifier.align(Alignment.CenterVertically).testTag(tag = tab.textId.toString()))
       }
     }
   }

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
@@ -40,6 +40,7 @@ constructor(
           it.copy(userId = null)
         }
       }
+      getMessages()
     }
   }
 

--- a/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
+++ b/app/src/main/java/com/github/se/eventradar/viewmodel/MessagesViewModel.kt
@@ -28,19 +28,17 @@ constructor(
 
   init {
     viewModelScope.launch {
-      _uiState.update {
-        val userId = userRepository.getCurrentUserId()
+      val userId = userRepository.getCurrentUserId()
 
-        if (userId is Resource.Success) {
-          it.copy(userId = userId.data)
-        } else {
-          Log.d(
-              "MessagesViewModel",
-              "Error getting user ID: ${(userId as Resource.Failure).throwable.message}")
-          it.copy(userId = null)
-        }
+      if (userId is Resource.Success) {
+        _uiState.update { it.copy(userId = userId.data) }
+        getMessages()
+      } else {
+        Log.d(
+            "MessagesViewModel",
+            "Error getting user ID: ${(userId as Resource.Failure).throwable.message}")
+        _uiState.update { it.copy(userId = null) }
       }
-      getMessages()
     }
   }
 

--- a/app/src/test/java/com/github/se/eventradar/MessagesViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eventradar/MessagesViewModelTest.kt
@@ -77,14 +77,13 @@ class MessagesViewModelTest {
 
   @Test
   fun testGetMessages() = runTest {
-    // TODO: fix logic with add message
     val mh = messagesRepository.createNewMessageHistory("1", "2")
 
     assert(mh is Resource.Success)
 
     val expectedMessage = Message("1", "Hello", LocalDateTime.now(), "1")
 
-    (mh as Resource.Success).data.messages.add(expectedMessage)
+    messagesRepository.addMessage(expectedMessage, (mh as Resource.Success).data)
 
     viewModel = MessagesViewModel(messagesRepository, userRepository)
 


### PR DESCRIPTION
**Description:**
This PR introduces comprehensive end-to-end tests for key messaging flows in the application. The new tests cover the following scenarios:

- **User Flow 1:**
  - Navigate from the home screen to the message screen.
  - Switch to the friend list tab.
  - View a friend's profile and open your conversation.
  - Send a message within the conversation.
  
- **User Flow 2:** 
  - Navigate from the home screen to the message screen.
  - Select a conversation from the messages list.
  - Send a message within the selected conversation.

Additionally, a logic oversight in MessagesTest.kt related to PR #307 has been fixed.

**Planned Future Work:**
End-to-end tests for event creation and profile editing will be added in a subsequent PR, as these functionalities are not yet merged into the main branch.