### PR TITLE
 Add end-to-end tests for create event and edit profile flows

### DIFF
--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -46,6 +46,7 @@ import com.github.se.eventradar.viewmodel.CreateEventViewModel
 import com.github.se.eventradar.viewmodel.EventDetailsViewModel
 import com.github.se.eventradar.viewmodel.EventsOverviewViewModel
 import com.github.se.eventradar.viewmodel.HostedEventsViewModel
+import com.github.se.eventradar.viewmodel.LoginViewModel
 import com.github.se.eventradar.viewmodel.MessagesViewModel
 import com.github.se.eventradar.viewmodel.ProfileViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -99,14 +100,16 @@ class UserFlowTests : TestCase() {
           email = "test@example.com",
           firstName = "John",
           lastName = "Doe",
-          phoneNumber = "1234567890",
+          phoneNumber = "123456789",
           accountStatus = "active",
           eventsAttendeeList = mutableListOf("event1", "event2"),
           eventsHostList = mutableListOf("event3"),
           friendsList = mutableListOf("user2"),
-          profilePicUrl = "http://example.com/Profile_Pictures/1",
-          qrCodeUrl = "http://example.com/QR_Codes/1",
-          bio = "",
+          profilePicUrl =
+              "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/Profile_Pictures%2FQKPpsHHs0NPkb5RzWgDMsL7cHQt2?alt=media&token=5769ac23-10b6-4013-a650-f81e79e6a276",
+          qrCodeUrl =
+              "https://firebasestorage.googleapis.com/v0/b/event-radar-e6a76.appspot.com/o/QR_Codes%2FQKPpsHHs0NPkb5RzWgDMsL7cHQt2?alt=media&token=4a0ba161-dfbc-4568-95b4-6c29309d41d9",
+          bio = "Hey all",
           username = "johndoe")
 
   private val user2 =
@@ -203,10 +206,12 @@ class UserFlowTests : TestCase() {
           }
           composable(Route.PROFILE) {
             val viewModel =
-                ProfileViewModel(userRepository, null) // userId = null leads to my prfile
+                ProfileViewModel(userRepository, null) // userId = null leads to my profile
             ProfileUi(isPublicView = false, viewModel = viewModel, navigationActions = navActions)
           }
-          composable(Route.LOGIN) { LoginScreen(navigationActions = navActions) }
+          composable(Route.LOGIN) {
+            LoginScreen(LoginViewModel(userRepository), navigationActions = navActions)
+          }
         }
       }
     }
@@ -539,22 +544,40 @@ class UserFlowTests : TestCase() {
       step("Click on the profile icon") { profileIcon.performClick() }
     }
     ComposeScreen.onComposeScreen<ProfileScreen>(composeTestRule) {
-      step("Check if edit button is displayed") { editProfile { assertIsDisplayed() } }
+      step("Check profile screen") { profileScreen { assertIsDisplayed() } }
+      step("Check if edit button is displayed") { editButton { assertIsDisplayed() } }
       step("Click on edit") { editButton { performClick() } }
       step("Edit profile") {
-        firstNameTextField { performTextInput("NewFirstName") }
-        saveButton { performClick() }
-      }
-
-      step("Log out") { logOutButton { performClick() } }
-    }
-
-    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-      step("Check if we are on the Login screen") {
-        eventRadarLogo { assertIsDisplayed() }
-        loginButton {
+        firstNameTextField {
+          performTextClearance()
+          performTextInput("NewFirstName")
+        }
+        saveButton {
           assertIsDisplayed()
           assertHasClickAction()
+          performClick()
+        }
+        name { assertTextContains("NewFirstName Doe") }
+        step("Log out is displayed") {
+          logOutButton {
+            assertIsDisplayed()
+            assertHasClickAction()
+            performClick()
+          }
+        }
+      }
+
+      ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+        step("Check if we are on the Login screen") {
+          eventRadarLogo { assertIsDisplayed() }
+          loginButton {
+            assertIsDisplayed()
+            assertHasClickAction()
+          }
+          signUpButton {
+            assertIsDisplayed()
+            assertHasClickAction()
+          }
         }
       }
     }

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -27,6 +27,7 @@ import com.github.se.eventradar.screens.CreateEventScreen
 import com.github.se.eventradar.screens.EventDetailsScreen
 import com.github.se.eventradar.screens.HomeScreen
 import com.github.se.eventradar.screens.HostingScreen
+import com.github.se.eventradar.screens.LoginScreen
 import com.github.se.eventradar.screens.MessagesScreen
 import com.github.se.eventradar.screens.ProfileScreen
 import com.github.se.eventradar.ui.chat.ChatScreen
@@ -34,6 +35,7 @@ import com.github.se.eventradar.ui.event.EventDetails
 import com.github.se.eventradar.ui.home.HomeScreen
 import com.github.se.eventradar.ui.hosting.CreateEventScreen
 import com.github.se.eventradar.ui.hosting.HostingScreen
+import com.github.se.eventradar.ui.login.LoginScreen
 import com.github.se.eventradar.ui.messages.MessagesScreen
 import com.github.se.eventradar.ui.navigation.NavigationActions
 import com.github.se.eventradar.ui.navigation.Route
@@ -199,6 +201,12 @@ class UserFlowTests : TestCase() {
                     CreateEventViewModel(locationRepository, eventRepository, userRepository),
                 navigationActions = navActions)
           }
+          composable(Route.PROFILE) {
+            val viewModel =
+                ProfileViewModel(userRepository, null) // userId = null leads to my prfile
+            ProfileUi(isPublicView = false, viewModel = viewModel, navigationActions = navActions)
+          }
+          composable(Route.LOGIN) { LoginScreen(navigationActions = navActions) }
         }
       }
     }
@@ -517,6 +525,37 @@ class UserFlowTests : TestCase() {
         eventList { assertIsDisplayed() }
         val newEvent = onNode { hasText("New Event") }
         newEvent { assertIsDisplayed() }
+      }
+    }
+  }
+  // User flow: homeScreen => my profile => edit profile => change first name => save => log out
+  @Test
+  fun homeScreenToEditProfileAndLogOut() = run {
+    ComposeScreen.onComposeScreen<HomeScreen>(composeTestRule) {
+      step("Check if elements are present") {
+        bottomNav { assertIsDisplayed() }
+        profileIcon { assertIsDisplayed() }
+      }
+      step("Click on the profile icon") { profileIcon.performClick() }
+    }
+    ComposeScreen.onComposeScreen<ProfileScreen>(composeTestRule) {
+      step("Check if edit button is displayed") { editProfile { assertIsDisplayed() } }
+      step("Click on edit") { editButton { performClick() } }
+      step("Edit profile") {
+        firstNameTextField { performTextInput("NewFirstName") }
+        saveButton { performClick() }
+      }
+
+      step("Log out") { logOutButton { performClick() } }
+    }
+
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      step("Check if we are on the Login screen") {
+        eventRadarLogo { assertIsDisplayed() }
+        loginButton {
+          assertIsDisplayed()
+          assertHasClickAction()
+        }
       }
     }
   }

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -474,18 +474,10 @@ class UserFlowTests : TestCase() {
     }
     ComposeScreen.onComposeScreen<CreateEventScreen>(composeTestRule) {
       ComposeScreen.onComposeScreen<CreateEventScreen>(composeTestRule) {
-        topBar {
-          assertIsDisplayed()
-        }
-        goBackButton {
-          assertIsDisplayed()
-        }
-        createEventText {
-          assertIsDisplayed()
-        }
-        createEventScreenColumn {
-          assertIsDisplayed()
-        }
+        topBar { assertIsDisplayed() }
+        goBackButton { assertIsDisplayed() }
+        createEventText { assertIsDisplayed() }
+        createEventScreenColumn { assertIsDisplayed() }
         eventImagePicker {
           performScrollTo()
           assertIsDisplayed()
@@ -567,9 +559,6 @@ class UserFlowTests : TestCase() {
         eventNameTextField { performTextInput("New Event") }
         eventDescriptionTextField { performTextInput("This is a test event") }
 
-//        eventCategoryDropDown { performClick() }
-      //event category, location, ticketname, organisers
-
         val eventCategoryOption = "MUSIC"
         step("Click on Event Category Drop Down Menu") {
           eventCategoryDropDown {
@@ -580,22 +569,26 @@ class UserFlowTests : TestCase() {
         }
         step("Check if Event Category Drop Down Menu is displayed") {
           composeTestRule
-            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+              .assertIsDisplayed()
         }
 
         step("Click on Specific Event Category") {
-          composeTestRule.onNode(
-            hasText(eventCategoryOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
-          ).assertIsDisplayed()
-          composeTestRule.onNode(
-            hasText(eventCategoryOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
-          ).performClick()
+          composeTestRule
+              .onNode(
+                  hasText(eventCategoryOption)
+                      .and(hasAnyAncestor(hasTestTag("exposedDropDownMenu"))))
+              .assertIsDisplayed()
+          composeTestRule
+              .onNode(
+                  hasText(eventCategoryOption)
+                      .and(hasAnyAncestor(hasTestTag("exposedDropDownMenu"))))
+              .performClick()
         }
         step("Check if Event Category Drop Down Menu is hidden") {
           composeTestRule
-            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
-            .assertIsNotDisplayed()
+              .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+              .assertIsNotDisplayed()
         }
         startDateTextField { performTextInput("2025-12-31") }
         endDateTextField { performTextInput("2026-01-01") }
@@ -612,24 +605,28 @@ class UserFlowTests : TestCase() {
         }
         step("Check if Location Drop Down Menu is displayed") {
           composeTestRule
-            .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
+              .assertIsDisplayed()
         }
         step("Click on Location Drop Down Menu Option") {
-          composeTestRule.onNode(
-            hasText(locationToVerify).and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu")))
-          ).assertIsDisplayed()
-          composeTestRule.onNode(
-            hasText(locationToVerify).and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu")))
-          ).performClick()
+          composeTestRule
+              .onNode(
+                  hasText(locationToVerify)
+                      .and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu"))))
+              .assertIsDisplayed()
+          composeTestRule
+              .onNode(
+                  hasText(locationToVerify)
+                      .and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu"))))
+              .performClick()
         }
         step("Check if Location Drop Down Menu is hidden") {
           composeTestRule
-            .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
-            .assertIsNotDisplayed()
+              .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
+              .assertIsNotDisplayed()
         }
 
-        //ticketName
+        // ticketName
         val ticketNameOption = "Standard"
         step("Click on ticket name text field") {
           ticketNameDropDownMenuTextField {
@@ -640,21 +637,23 @@ class UserFlowTests : TestCase() {
         }
         step("Check if ticketName drop down menu is displayed") {
           composeTestRule
-            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+              .assertIsDisplayed()
         }
         step("Click on ticketName Option") {
-          composeTestRule.onNode(
-            hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
-          ).assertIsDisplayed()
-          composeTestRule.onNode(
-            hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
-          ).performClick()
+          composeTestRule
+              .onNode(
+                  hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu"))))
+              .assertIsDisplayed()
+          composeTestRule
+              .onNode(
+                  hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu"))))
+              .performClick()
         }
         step("Check if ticketName drop down menu is hidden") {
           composeTestRule
-            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
-            .assertIsNotDisplayed()
+              .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+              .assertIsNotDisplayed()
         }
 
         ticketQuantityTextField { performTextInput("100") }
@@ -674,56 +673,55 @@ class UserFlowTests : TestCase() {
         }
         step("Check if Organisers Drop Down Menu is displayed") {
           composeTestRule
-            .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
+              .assertIsDisplayed()
         }
         step("Click on organiser Option") {
-          composeTestRule.onNode(
-            hasText(friendUserName).and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu")))
-          ).assertIsDisplayed()
-          composeTestRule.onNode(
-            hasText(friendUserName).and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu")))
-          ).performClick()
+          composeTestRule
+              .onNode(
+                  hasText(friendUserName)
+                      .and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu"))))
+              .assertIsDisplayed()
+          composeTestRule
+              .onNode(
+                  hasText(friendUserName)
+                      .and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu"))))
+              .performClick()
         }
         step("Click on Organisers Drop Down Toggle Icon") {
           composeTestRule
-            .onNodeWithTag("multiSelectDropDownToggleIcon", useUnmergedTree = true)
-            .performClick()
+              .onNodeWithTag("multiSelectDropDownToggleIcon", useUnmergedTree = true)
+              .performClick()
         }
         step("Check if Organisers Drop Down is hidden") {
           composeTestRule
-            .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
-            .assertIsNotDisplayed()
+              .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
+              .assertIsNotDisplayed()
         }
 
-        step("Publish Event") { publishEventButton {
-          performScrollTo()
-          performClick()
-        } }
+        step("Publish Event") {
+          publishEventButton {
+            performScrollTo()
+            performClick()
+          }
+        }
         step("Check if success dialog box is displayed") {
           composeTestRule
-            .onNodeWithTag("successDialogBox", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("successDialogBox", useUnmergedTree = true)
+              .assertIsDisplayed()
           composeTestRule.onNodeWithTag("DisplayText", useUnmergedTree = true).assertIsDisplayed()
           composeTestRule.onNodeWithTag("DisplayTitle", useUnmergedTree = true).assertIsDisplayed()
           composeTestRule
-            .onNodeWithTag("dialogConfirmButton", useUnmergedTree = true)
-            .assertIsDisplayed()
+              .onNodeWithTag("dialogConfirmButton", useUnmergedTree = true)
+              .assertIsDisplayed()
         }
         step("Click on confirm") {
-          composeTestRule.onNodeWithTag("dialogConfirmButton", useUnmergedTree = true).performClick()
+          composeTestRule
+              .onNodeWithTag("dialogConfirmButton", useUnmergedTree = true)
+              .performClick()
         }
-
       }
-
     }
-//    ComposeScreen.onComposeScreen<HostingScreen>(composeTestRule) {
-//      step("Verify Event is Listed in Hosted Events") {
-//        eventList { assertIsDisplayed() }
-//        val newEvent = onNode { hasText("New Event") }
-//        newEvent { assertIsDisplayed() }
-//      }
-//    }
   }
   // User flow: homeScreen => my profile => edit profile => change first name => save => log out
   @Test

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -1,6 +1,13 @@
 package com.github.se.eventradar.endtoend
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -466,49 +473,190 @@ class UserFlowTests : TestCase() {
       step("Click on create event") { createEventFab.performClick() }
     }
     ComposeScreen.onComposeScreen<CreateEventScreen>(composeTestRule) {
-      topBar { assertIsDisplayed() }
-      goBackButton { assertIsDisplayed() }
-      createEventText { assertIsDisplayed() }
-      createEventScreenColumn { assertIsDisplayed() }
-      eventImagePicker { assertIsDisplayed() }
-      eventNameTextField { assertIsDisplayed() }
-      eventDescriptionTextField { assertIsDisplayed() }
-      datesRow { assertIsDisplayed() }
-      startDateTextField { assertIsDisplayed() }
-      endDateTextField { assertIsDisplayed() }
-      timesRow { assertIsDisplayed() }
-      startTimeTextField { assertIsDisplayed() }
-      endTimeTextField { assertIsDisplayed() }
-      locationExposedDropDownMenuBox { assertIsDisplayed() }
-      locationDropDownMenuTextField { assertIsDisplayed() }
-      exposedDropDownMenuBox { assertIsDisplayed() }
-      ticketNameDropDownMenuTextField { assertIsDisplayed() }
-      eventCategoryDropDown { assertIsDisplayed() }
-      ticketQuantityTextField { assertIsDisplayed() }
-      ticketPriceTextField { assertIsDisplayed() }
+      ComposeScreen.onComposeScreen<CreateEventScreen>(composeTestRule) {
+        topBar {
+          assertIsDisplayed()
+        }
+        goBackButton {
+          assertIsDisplayed()
+        }
+        createEventText {
+          assertIsDisplayed()
+        }
+        createEventScreenColumn {
+          assertIsDisplayed()
+        }
+        eventImagePicker {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        eventNameTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        eventDescriptionTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        datesRow {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        startDateTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        endDateTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        timesRow {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        startTimeTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        endTimeTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        locationExposedDropDownMenuBox {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        locationDropDownMenuTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        exposedDropDownMenuBox {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        ticketNameDropDownMenuTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        eventCategoryDropDown {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        ticketQuantityTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        ticketPriceTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        multiSelectExposedDropDownMenuBox {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        organisersMultiDropDownMenuTextField {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+        publishEventButton {
+          performScrollTo()
+          assertIsDisplayed()
+        }
+      }
       step("Fill in Event Details") {
         eventNameTextField { performTextInput("New Event") }
         eventDescriptionTextField { performTextInput("This is a test event") }
-        eventCategoryDropDown { performClick() }
 
-        val categoryOption = onNode { hasText("MUSIC") }
+//        eventCategoryDropDown { performClick() }
+      //event category, location, ticketname, organisers
 
-        // categoryOption {
-        //     assertIsDisplayed()
-        //     performClick()
-        // }
+        val eventCategoryOption = "MUSIC"
+        step("Click on Event Category Drop Down Menu") {
+          eventCategoryDropDown {
+            performScrollTo()
+            assertIsDisplayed()
+            performClick()
+          }
+        }
+        step("Check if Event Category Drop Down Menu is displayed") {
+          composeTestRule
+            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+            .assertIsDisplayed()
+        }
+
+        step("Click on Specific Event Category") {
+          composeTestRule.onNode(
+            hasText(eventCategoryOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
+          ).assertIsDisplayed()
+          composeTestRule.onNode(
+            hasText(eventCategoryOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
+          ).performClick()
+        }
+        step("Check if Event Category Drop Down Menu is hidden") {
+          composeTestRule
+            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+            .assertIsNotDisplayed()
+        }
         startDateTextField { performTextInput("2025-12-31") }
         endDateTextField { performTextInput("2026-01-01") }
         startTimeTextField { performTextInput("10:00") }
         endTimeTextField { performTextInput("18:00") }
-        eventCategoryDropDown { performClick() }
-
-        locationDropDownMenuTextField {
-          performClick()
-          performTextInput("EPFL")
+        val locationToSearch = "EPFL"
+        val locationToVerify = "École polytechnique fédérale de Lausanne"
+        step("Click on Location text field and type in it") {
+          locationDropDownMenuTextField {
+            assertIsDisplayed()
+            performClick()
+            performTextInput(locationToSearch)
+          }
+        }
+        step("Check if Location Drop Down Menu is displayed") {
+          composeTestRule
+            .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
+            .assertIsDisplayed()
+        }
+        step("Click on Location Drop Down Menu Option") {
+          composeTestRule.onNode(
+            hasText(locationToVerify).and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu")))
+          ).assertIsDisplayed()
+          composeTestRule.onNode(
+            hasText(locationToVerify).and(hasAnyAncestor(hasTestTag("locationExposedDropDownMenu")))
+          ).performClick()
+        }
+        step("Check if Location Drop Down Menu is hidden") {
+          composeTestRule
+            .onNodeWithTag("locationExposedDropDownMenu", useUnmergedTree = true)
+            .assertIsNotDisplayed()
         }
 
-        ticketNameDropDownMenuTextField { performTextInput("General Admission") }
+        //ticketName
+        val ticketNameOption = "Standard"
+        step("Click on ticket name text field") {
+          ticketNameDropDownMenuTextField {
+            performScrollTo()
+            assertIsDisplayed()
+            performClick()
+          }
+        }
+        step("Check if ticketName drop down menu is displayed") {
+          composeTestRule
+            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+            .assertIsDisplayed()
+        }
+        step("Click on ticketName Option") {
+          composeTestRule.onNode(
+            hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
+          ).assertIsDisplayed()
+          composeTestRule.onNode(
+            hasText(ticketNameOption).and(hasAnyAncestor(hasTestTag("exposedDropDownMenu")))
+          ).performClick()
+        }
+        step("Check if ticketName drop down menu is hidden") {
+          composeTestRule
+            .onNodeWithTag("exposedDropDownMenu", useUnmergedTree = true)
+            .assertIsNotDisplayed()
+        }
+
         ticketQuantityTextField { performTextInput("100") }
 
         ticketPriceTextField {
@@ -516,22 +664,66 @@ class UserFlowTests : TestCase() {
           performTextInput("10.0")
         }
 
-        organisersMultiDropDownMenuTextField { performClick() }
-        val organiser = onNode { hasText("John Doe") }
-        organiser {
-          assertIsDisplayed()
-          performClick()
+        val friendUserName = user2.username
+        step("Click on Organisers Drop Down Menu") {
+          organisersMultiDropDownMenuTextField {
+            performScrollTo()
+            assertIsDisplayed()
+            performClick()
+          }
         }
+        step("Check if Organisers Drop Down Menu is displayed") {
+          composeTestRule
+            .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
+            .assertIsDisplayed()
+        }
+        step("Click on organiser Option") {
+          composeTestRule.onNode(
+            hasText(friendUserName).and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu")))
+          ).assertIsDisplayed()
+          composeTestRule.onNode(
+            hasText(friendUserName).and(hasAnyAncestor(hasTestTag("multiSelectExposedDropdownMenu")))
+          ).performClick()
+        }
+        step("Click on Organisers Drop Down Toggle Icon") {
+          composeTestRule
+            .onNodeWithTag("multiSelectDropDownToggleIcon", useUnmergedTree = true)
+            .performClick()
+        }
+        step("Check if Organisers Drop Down is hidden") {
+          composeTestRule
+            .onNodeWithTag("multiSelectExposedDropdownMenu", useUnmergedTree = true)
+            .assertIsNotDisplayed()
+        }
+
+        step("Publish Event") { publishEventButton {
+          performScrollTo()
+          performClick()
+        } }
+        step("Check if success dialog box is displayed") {
+          composeTestRule
+            .onNodeWithTag("successDialogBox", useUnmergedTree = true)
+            .assertIsDisplayed()
+          composeTestRule.onNodeWithTag("DisplayText", useUnmergedTree = true).assertIsDisplayed()
+          composeTestRule.onNodeWithTag("DisplayTitle", useUnmergedTree = true).assertIsDisplayed()
+          composeTestRule
+            .onNodeWithTag("dialogConfirmButton", useUnmergedTree = true)
+            .assertIsDisplayed()
+        }
+        step("Click on confirm") {
+          composeTestRule.onNodeWithTag("dialogConfirmButton", useUnmergedTree = true).performClick()
+        }
+
       }
-      step("Publish Event") { publishEventButton { performClick() } }
+
     }
-    ComposeScreen.onComposeScreen<HostingScreen>(composeTestRule) {
-      step("Verify Event is Listed in Hosted Events") {
-        eventList { assertIsDisplayed() }
-        val newEvent = onNode { hasText("New Event") }
-        newEvent { assertIsDisplayed() }
-      }
-    }
+//    ComposeScreen.onComposeScreen<HostingScreen>(composeTestRule) {
+//      step("Verify Event is Listed in Hosted Events") {
+//        eventList { assertIsDisplayed() }
+//        val newEvent = onNode { hasText("New Event") }
+//        newEvent { assertIsDisplayed() }
+//      }
+//    }
   }
   // User flow: homeScreen => my profile => edit profile => change first name => save => log out
   @Test

--- a/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/endtoend/UserFlowTest.kt
@@ -595,7 +595,7 @@ class UserFlowTests : TestCase() {
         startTimeTextField { performTextInput("10:00") }
         endTimeTextField { performTextInput("18:00") }
         val locationToSearch = "EPFL"
-        val locationToVerify = "École polytechnique fédérale de Lausanne"
+        val locationToVerify = "EPFL"
         step("Click on Location text field and type in it") {
           locationDropDownMenuTextField {
             assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/eventradar/screens/ProfileScreen.kt
+++ b/app/src/androidTest/java/com/github/se/eventradar/screens/ProfileScreen.kt
@@ -46,5 +46,5 @@ class ProfileScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val phoneNumberBirthDateSpacer: KNode =
       phoneNumberBirthDateRow.child { hasTestTag("phoneNumberBirthDateSpacer") }
   val saveButton: KNode = centeredViewProfileColumn.child { hasTestTag("saveButton") }
-  val logOutButton: KNode = centeredViewProfileColumn.child { hasTestTag("logOutButton") }
+  val logOutButton: KNode = leftAlignedViewProfileColumn.child { hasTestTag("logOutButton") }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
@@ -9,12 +9,7 @@ class MockLocationRepository : ILocationRepository {
       Resource.Failure(Exception("Empty location name is invalid"))
     } else {
       Resource.Success(
-          listOf(
-              Location(
-                  latitude = 100.0,
-                  longitude = 100.0,
-                  address = "École polytechnique fédérale de Lausanne"),
-              Location(latitude = 100.0, longitude = 100.0, address = locationName)))
+          listOf(Location(latitude = 100.0, longitude = 100.0, address = locationName)))
     }
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
@@ -10,10 +10,11 @@ class MockLocationRepository : ILocationRepository {
     } else {
       Resource.Success(
           listOf(
-            Location(latitude = 100.0, longitude = 100.0, address = "École polytechnique fédérale de Lausanne"),
-            Location(latitude = 100.0, longitude = 100.0, address = locationName)
-          )
-      )
+              Location(
+                  latitude = 100.0,
+                  longitude = 100.0,
+                  address = "École polytechnique fédérale de Lausanne"),
+              Location(latitude = 100.0, longitude = 100.0, address = locationName)))
     }
   }
 }

--- a/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
+++ b/app/src/main/java/com/github/se/eventradar/model/repository/location/MockLocationRepository.kt
@@ -9,7 +9,11 @@ class MockLocationRepository : ILocationRepository {
       Resource.Failure(Exception("Empty location name is invalid"))
     } else {
       Resource.Success(
-          listOf(Location(latitude = 100.0, longitude = 100.0, address = locationName)))
+          listOf(
+            Location(latitude = 100.0, longitude = 100.0, address = "École polytechnique fédérale de Lausanne"),
+            Location(latitude = 100.0, longitude = 100.0, address = locationName)
+          )
+      )
     }
   }
 }


### PR DESCRIPTION
## Description:
This PR introduces comprehensive end-to-end tests for key user flows related to profile management and event creation in the application. The new tests cover the following scenarios:

**User Flow 1:**
- Navigate from the home screen to the profile screen.
- Edit the profile by changing the first name.
- Save the changes and verify the profile is updated.
- Log out and ensure the user is navigated to the login screen.

**User Flow 2:**
- Navigate from the home screen to the hosting screen.
- Initiate the event creation process.
- Fill in all required fields to create a new event.
- Publish the event and verify success dialog box.